### PR TITLE
rooms: persistent multi-party chat for clive-to-clive (phases 0–4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .venv/
+.worktrees/
 __pycache__/
 .eval_cache/
 .clive/audit/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## 0.6.0 — Rooms: persistent multi-party chat (experimental) (2026-04-14)
+
+A new primitive for N-way clive-to-clive collaboration: always-on **lobby** brokers hosting persistent **rooms** that any number of members can join and converse inside **threads**. Each thread runs a uniform round-robin with first-class `pass`, so three or more agents don't trample each other. Phases 0–4 of the [13-section design doc](docs/plans/2026-04-14-clive-rooms-design.md) shipped; SSH transport, JSONL persistence, dropouts/timeouts, rolling summaries, rate limits, and private-thread breakout councils are queued for 0.7.
+
+### Added
+
+- **Rooms protocol** (`networking/protocol.py`) — Extends `KINDS` with 14 new frame kinds: `session_hello`/`session_ack`, `join_room`, `list_threads`/`threads`, `open_thread`/`thread_opened`/`close_thread`, `join_thread`/`leave_thread`, `your_turn`, `say`, `pass`, `nack`. The `your_turn` frame carries the full thread context structurally (recent-K, optional summary, member list) rather than relying on pane scrollback — see design §4.2.
+
+- **Pure lobby state machine** (`networking/lobby_state.py`) — `handle(state, session_id, frame, now) -> list[Send]` is a pure function: given state and a frame, mutate state in place and return outbound frames. Rooms, threads, round-robin rotation, quiescence detection, fanout (public = thread members ∪ room observers minus sender; private = thread members only), initiator-only close authorization. 43 tests cover the decision tree without touching sockets.
+
+- **Lobby IO server** (`networking/lobby_server.py`) — Thin selectors-based Unix socket wrapper around the state machine. Per-connection `NONCE <value>\n` handshake, framed line IO, owner-only socket permissions (umask-tightened around `bind` + explicit chmod), self-pipe shutdown, graceful accept-error recovery. Enabled via `python clive.py --role broker --name <lobbyname>`.
+
+- **SSH client wrapper** (`networking/lobby_client.py`) — Tiny bridge process invoked as the SSH remote command. Reads `CLIVE_FRAME_NONCE` from env (forwarded via SendEnv), connects the lobby Unix socket, sends the handshake line, then bidi-pipes stdin ↔ socket ↔ stdout. Transparent — never parses frames. Reachable via `--role lobby-client`.
+
+- **Room driver** (`drivers/room.md`) — Static response-format driver for room turns. Emits `say: <body>` / `DONE:` or `pass:` / `DONE:`; driver emphasises pass-is-the-norm and forbids reproducing the recent messages, addressing members by name, or trying to seize the next turn.
+
+- **Client-side room runner** (`execution/room_runner.py`) — Pure turn decider: takes a `your_turn` payload + an LLM client, returns exactly one `(kind, payload)` pair. Malformed LLM output (no directive, empty say body, missing `DONE:`, garbled text, `llm.chat` exceptions) degrades to `pass` — emitting a nacked frame would waste the turn and the lobby auto-passes anyway. 17 tests.
+
+- **`RoomParticipant`** (`execution/room_participant.py`) — Transport-agnostic stateful glue. Owns the per-session nonce and member identity; `bootstrap(rooms)` returns the `session_hello` + `join_room` sequence, `on_line(line)` decodes inbound lobby traffic and returns outbound frames via `decide_turn`. Driver text is lazy-cached after first `your_turn`. 12 tests including an end-to-end integration against a real `LobbyServer`.
+
+- **Selectors-based conversational loop** (`session/conv_loop.py`) — Prerequisite for rooms wire-up: replaces `clive.py`'s blocking `sys.stdin.readline()` with a `ConvLoop` that can multiplex stdin + any number of additional readable fds. Line framing uses raw `os.read` + per-source byte buffers (Python's text buffer can stash bytes past a newline such that `select()` reports nothing readable while more lines sit unread). Self-pipe lets `stop()` wake `select()` from another thread. Handler exceptions are logged and swallowed — matches the pre-refactor emit-failure-frame contract. Partial-final-line EOF is delivered (parity with `readline()`'s tail-on-EOF behaviour); the original blocking flag is restored on each registered fd at teardown. 9 tests.
+
+- **`--join room@lobby` CLI flag** — Repeatable. Rooms are grouped by lobby so a single socket carries all a member's rooms on that lobby. `--join` auto-enables `--conversational` and requires `--name` (so the member is identifiable on the lobby); both requirements are enforced at argparse time with exit 2 + a helpful stderr message rather than silently doing nothing.
+
+- **Localhost lobby connector** (`networking/lobby_connector.py`) — `connect_local(lobby_name)` reads the instance registry, validates the `role: broker` + `socket_path` fields, opens a blocking Unix socket, and completes the NONCE handshake. Fresh nonce per connection via `protocol.generate_nonce` (explicit nonces are alphabet-validated up front to fail loudly rather than via downstream closed-socket symptoms). Dedicated `ConnectError` so callers can distinguish resolution failures from generic IO errors. 7 tests.
+
+- **Registry `role` + `socket_path` fields** — `registry.register()` gains two optional fields so consumers can find the broker's Unix socket without a round-trip. Existing consumers ignore unknown keys (§9.6).
+
+- **CLI end-to-end test** (`tests/test_rooms_cli.py`) — Spawns a real `--role broker` subprocess, then a member subprocess with `--join`, then uses a third raw-socket observer to verify the member is actually in-room by opening a thread listing them as a member (the lobby's `open_thread` validator returns `thread_opened` iff the member joined, which pins the whole CLI path). Runs in ~3 seconds.
+
+### Security
+
+- **Per-session nonces** — Each lobby session handshakes with its own nonce; outbound frames are stamped with the recipient's nonce so a compromised member cannot forge fanout for another member (the other member's stream decodes with a different nonce). `from:` labels on `say`/`pass` are lobby-authored.
+
+- **Socket permissions** — Broker socket is `0o600` from the moment it exists (`umask(0o077)` wrapped around `bind()`, explicit `chmod` as defence-in-depth). Parent `~/.clive/lobby/` is created with mode `0o700`.
+
+- **Broker name collision refused** — Starting a second `--role broker` under the same `--name` raises a clear error before touching the filesystem rather than silently `unlink`ing the first broker's socket and clobbering its registry entry.
+
+- **Private-thread invisibility** — Design §7.1 guarantees private threads (breakout councils) are fully hidden from `list_threads` and all fanout for non-members; state-machine tests pin the invariant.
+
+### Docs
+
+- **Full design doc** at [`docs/plans/2026-04-14-clive-rooms-design.md`](docs/plans/2026-04-14-clive-rooms-design.md) — 13 sections, ~540 lines: non-goals, core concepts, turn discipline, protocol, lobby implementation, client-side architecture, access-control & trust model, bootstrap & deployment, system-interaction deltas, testing strategy, 12-phase implementation plan, open items, decision summary. Updated in-commit to reflect v1 narrowings (human-initiated threads deferred; name-reuse-after-drop accepted v1 behaviour).
+
+- **README §Rooms** — New section between "Named instances" and "Long-running disconnected tasks" describing the feature with a three-terminal quickstart.
+
+### Tests
+
+23 new test files / sections, ~100 new test cases. Repo test count: 891 → 894. Fresh-eyes reviews between every phase committed 5 separate correctness-fix commits that caught: broker name collision clobbering, `sendall` on non-blocking socket silently exiting, `accept()` killing the event loop on `EMFILE`, socket-mode TOCTOU, self-pipe fd reuse, partial-final-line EOF dropped, non-blocking flag leaking across tests, driver re-read per turn, `--join` silently no-oping without `--name` or `--conversational`, nonce alphabet not validated.
+
 ## 0.5.0 — LLM-native mode & cross-task memory (2026-04-14)
 
 A new execution mode where the LLM *is* the tool — for tasks where generation is the work (translate, summarize, rewrite, extract, classify, explain) rather than something you drive a shell to do. Plus the REPL and TUI now carry state across tasks, so follow-up references like "translate the transcript" resolve without clarification.

--- a/README.md
+++ b/README.md
@@ -522,6 +522,27 @@ clive --stop researcher
 
 **Dashboard in TUI:** Use `/dashboard` in the TUI for the same view.
 
+### Rooms — persistent multi-party chat (experimental)
+
+Agent-to-agent (`clive@host`) is point-to-point. For round-table discussions involving three or more members — a council convening to review a design, a pool of specialists picking up whichever question matches their domain, a long-running channel where anyone can drop in — clive provides **rooms**: persistent Slack-channel-like venues brokered by an always-on lobby process. Threads inside a room enforce a first-class **pass-is-the-norm** round-robin so N clives don't talk over each other.
+
+```bash
+# Terminal A: start the lobby
+python clive.py --role broker --name lobby
+
+# Terminal B: alice auto-joins `general` on the lobby
+python clive.py --name alice --conversational --join general@lobby
+
+# Terminal C: bob
+python clive.py --name bob --conversational --join general@lobby
+```
+
+On each `your_turn` grant the member's `drivers/room.md`-guided LLM responds with exactly one of `say: <body>` / `pass:`. The lobby fans messages to room observers, rotates the cursor to the next member, and enforces turn discipline so out-of-turn `say` frames are nacked.
+
+**Design references:** the full 13-section design doc lives at [`docs/plans/2026-04-14-clive-rooms-design.md`](docs/plans/2026-04-14-clive-rooms-design.md) — covers room/thread model, turn discipline, breakout councils via private threads, the framed nonce-authenticated protocol extensions, the lobby state machine, persistence plan (Phase 5), and the full threat model.
+
+**Status:** phases 0–4 shipped (protocol kinds, pure state machine, selectors-based IO server, client-side room runner, `--join` CLI flag with localhost resolution). Remote (SSH) transport and persistence / dropouts / summarization / rate limits come next. Enable with `python clive.py --role broker --name <lobbyname>` + `--join room@lobbyname` on each member.
+
 ### Long-running disconnected tasks
 
 If your local machine sleeps, the SSH session drops. For tasks that run overnight, start the agent on the remote host inside its own tmux session:

--- a/docs/plans/2026-04-14-clive-rooms-design.md
+++ b/docs/plans/2026-04-14-clive-rooms-design.md
@@ -21,6 +21,7 @@
 - **Multi-broker federation.** One lobby per deployment.
 - **Real-time UX guarantees.** 60-second auto-pass on turns is acceptable.
 - **Late admission into private threads.** Private threads have fixed membership at `open_thread` time; rejoin-after-drop works but third-party join does not. A dedicated admission protocol can be added later.
+- **Human-initiated threads.** V1 requires the initiator to be a clive (because the initiator sits at `members[0]` and humans are never in rotation). Humans participate as observers and message-injectors only. The separation between a thread's `initiator` concept and its `members` rotation list — which would allow a human to own a thread without being in its rotation — is deferred; no current use case requires it.
 
 ---
 
@@ -86,11 +87,11 @@ If **zero** members are online, the thread is **stalled**, not dormant. The curs
 
 ### 3.3 Humans
 
-Humans declare `client_kind: human` in `session_hello`. They are **observers + latent initiators**, never in rotation.
+Humans declare `client_kind: human` in `session_hello`. They are **observers + message injectors**, never in rotation.
 
 - Humans never receive `your_turn` and are never `current_speaker`.
-- Humans can emit `say` into any thread they are room-members of at any time. The lobby accepts human `say` unconditionally (it bypasses the current_speaker check) and treats it as a **new prompt** — it is fanned out to all thread members, the rotation cursor resets to the initiator (or the next clive member after position 0), and a fresh rotation begins.
-- Humans can `open_thread` like any clive member; they become the initiator.
+- Humans can emit `say` into any public thread in a room they have joined. The lobby accepts human `say` without the current_speaker check; it is fanned out to the thread's recipient set, the rotation cursor resets to position 0 (the clive initiator), and a fresh rotation begins. Private threads require the human to be on `members`; otherwise the inject is nacked with `private_thread` (the fanout isolation in §7.1 is symmetric).
+- **Humans cannot `open_thread` in v1.** Because `members[0]` is defined as the initiator and humans are not permitted in `members`, a human `open_thread` fails validation. Human-initiated threads are a deferred feature (§1 non-goals, §12 open items) — a human steers by joining a room and injecting `say`, or by asking a clive to open a thread on their behalf.
 - Humans observe non-private threads in their room via the normal fanout pipeline.
 
 The asymmetry is deliberate: a human closing a laptop lid must never block a clive-to-clive rotation.
@@ -386,6 +387,7 @@ Unchanged from today's `networking/protocol.py`. Each SSH session has its own no
 | Stalled rotation (all offline) | Cursor holds; first returning member resumes. |
 | Lobby host compromise | Out of scope — trust boundary. |
 | Human session impersonation | Requires SSH access, which is the trust boundary. |
+| Name reuse after session drop claims an in-thread identity | **Accepted v1 behaviour.** When a session drops, `name_to_session` frees the name but `thread.members` still lists it; a new session can claim the name and step into the rotation slot. This is acceptable because SSH access to the lobby is the sole trust boundary — anyone who can do this is already trusted. To remove the behaviour a future iteration could bind thread membership to session-id instead of name, at the cost of breaking legitimate reconnects. |
 
 ### 7.4 What the outer LLM sees
 
@@ -509,7 +511,7 @@ Each phase ships something usable, in order:
 7. **Rolling summarization.** Background thread, K=50 threshold, sidecar summary file, `your_turn.summary` population.
 8. **Private threads / breakout councils.** `private: true`, fanout isolation, full invisibility in `list_threads`.
 9. **Rate limits & size caps.** `open_thread` counters, `max_say_bytes`, `max_active_initiated_threads`.
-10. **Human sessions.** `client_kind: human` acceptance, cursor-reset on human `say`, SSH TUI glue for humans to attach.
+10. **Human sessions.** `client_kind: human` acceptance; room-membership and private-thread-membership enforcement for human `say`; cursor-reset on inject; SSH TUI glue for humans to attach. Does NOT include human-initiated threads — that's deferred per §12.
 11. **Integration evals.** `layer4_rooms.py` and friends.
 
 Phase 3 is already enough to run an ephemeral council between two clives on localhost.
@@ -518,6 +520,7 @@ Phase 3 is already enough to run an ephemeral council between two clives on loca
 
 ## 12. Open items & future work
 
+- **Human-initiated threads.** V1 keeps `members[0] == initiator` and forbids humans in `members`, so humans cannot open threads directly. A later design can separate `thread.initiator` (authority over `close_thread`, ownership) from the `members` rotation list — allowing a human to own a thread of all-clive participants without being in the rotation. Schema change required: `open_thread` would gain an `initiator` field (or a `rotation_members` field distinct from `initiator`).
 - **Per-room K.** Hardcoded at 50 in v1; make configurable when a concrete verbose-room case appears.
 - **Lobby failover / election.** Single broker is a SPOF. Cold-start from snapshot on a secondary host, or consensus-based election, is future work.
 - **Invite-only rooms.** `private_room: true` with an explicit invite list.
@@ -540,7 +543,7 @@ Phase 3 is already enough to run an ephemeral council between two clives on loca
 2. **Always-on broker** (`clive@lobby`) on a dedicated host, snapshot to disk.
 3. **Uniform round-robin turn discipline** with first-class `pass`.
 4. **Initiator-owns-thread** with ownership transfer on drop.
-5. **Humans observe + initiate, never rotated;** their `say` resets the cursor.
+5. **Humans observe + inject, never rotated;** their `say` resets the cursor. V1 does not support human-initiated threads (deferred — see §1, §12).
 6. **Lobby is deterministic protocol only,** LLM solely for rolling summaries.
 7. **K=50 recent window + rolling summary,** hardcoded.
 8. **`your_turn` carries structured context** — pane-as-context is explicitly abandoned for room participation to avoid multi-thread scrollback interleaving. Scrollback remains human-observable.

--- a/docs/plans/2026-04-14-clive-rooms-design.md
+++ b/docs/plans/2026-04-14-clive-rooms-design.md
@@ -1,0 +1,555 @@
+# Clive Rooms — Persistent Multi-Party Chat & Breakout Councils
+
+> **For Claude:** When this document is ready for execution, wrap task breakdown in a separate plan file and invoke `superpowers:executing-plans` from there. This document is the design, not the execution plan.
+
+**Goal.** Enable multiple clive instances (and humans) to participate in persistent, long-lived rooms hosted by an always-on broker, with round-robin turn discipline and first-class support for ephemeral private breakout councils. Rooms are named containers; **threads** are the unit of conversation inside them. Breakout councils are just threads with a restricted member list and `private: true` — one mechanism serves both use cases.
+
+**Architecture.** A dedicated always-on host runs `clive@lobby`, a new `--role broker` mode of clive that swaps the planner/executor for a deterministic, single-threaded event-loop protocol service. Member clives connect via existing SSH agent-addressing. The lobby authenticates, enforces turn order, fans out messages, and snapshots threads to disk. An LLM is used only for rolling thread summarization.
+
+**Tech stack.** Existing `networking/protocol.py` (extended with new frame kinds); existing SSH agent-addressing and named-instance registry; `selectors` stdlib for lobby IO; append-only JSONL snapshots.
+
+**Governing principle from SPEC.md.** *"LLM where judgment is required, shell everywhere else."* The lobby is the one piece of the system that is explicitly *not* allowed to have judgment. LLM judgment lives in member clives; the lobby's sole LLM call-site is summarization.
+
+---
+
+## 1. Non-goals (v1)
+
+- **Election / failover.** A single always-on broker is the v1 answer. If the lobby host is down, rooms are unavailable.
+- **Pane-as-context for room participation.** Rooms deliberately break clive's usual "the pane scrollback IS the sub-agent's context" principle because a single member in multiple threads would see all threads' transcripts interleaved in one pane. Room context is delivered as structured payload inside `your_turn` frames; the scrollback is for human observability only.
+- **Invite-only rooms.** All rooms are open-by-default within the lobby; SSH access to the lobby host is the only access gate.
+- **Per-member identity beyond SSH.** No user accounts. If you can SSH to the lobby, you are trusted inside it.
+- **Multi-broker federation.** One lobby per deployment.
+- **Real-time UX guarantees.** 60-second auto-pass on turns is acceptable.
+- **Late admission into private threads.** Private threads have fixed membership at `open_thread` time; rejoin-after-drop works but third-party join does not. A dedicated admission protocol can be added later.
+
+---
+
+## 2. Core concepts
+
+### 2.1 Room
+
+A named persistent container. Properties:
+
+- **name** — short identifier, unique per lobby.
+- **membership** — ephemeral; a member exists in a room only while its SSH session is alive and has issued `join_room`. SSH drop = member removed.
+- **threads** — list of threads ever opened in this room, regardless of state.
+
+Rooms are snapshotted to disk and survive lobby restarts. Membership is not snapshotted.
+
+### 2.2 Thread
+
+The unit of conversation. Properties:
+
+- **thread_id** — assigned by the lobby (format `{room}-t{n}`), never by the client.
+- **room** — the parent room.
+- **initiator** — the member who opened it; initial owner.
+- **members** — **ordered** list of rotation participants. Fixed at `open_thread` time for private threads; appendable by public-thread `join_thread` for latecomers.
+- **private** — boolean; if `true`, the thread is completely invisible in `list_threads` to non-members — its id, members, and very existence are hidden.
+- **state** — `open` | `dormant` | `closed`.
+- **current_speaker** — rotation cursor; the member whose turn it currently is.
+- **messages** — append-only log of `say` / `pass` events (persisted as JSONL).
+
+Breakout councils are `private: true` threads. No separate concept.
+
+### 2.3 Rotation and pass
+
+Rotation is an ordered walk over `members`. Every turn ends with exactly one frame from `current_speaker` — either `say` (substantive) or `pass` ("nothing"). Both advance the cursor. Passing is per-turn: a member who passed on message 5 may speak substantively on message 6. The room driver instructs members to pass liberally; pass is the norm.
+
+### 2.4 Session kind
+
+Each SSH session to the lobby declares itself `clive` or `human` via a `session_hello` frame immediately after connection. The lobby uses this only to route message-injection semantics (§3.3); it is not a trust differentiator (SSH is).
+
+---
+
+## 3. Turn discipline
+
+1. **Threads are the unit of conversation.** Turn discipline applies within a thread; a room with N open threads has N independent rotations.
+2. **Only `current_speaker` may emit `say` or `pass`** in a given thread. Out-of-turn frames receive a `nack` and are dropped.
+3. **Every turn ends with exactly one frame** — `say` or `pass`.
+4. **Rotation advances on every turn.**
+5. **Consecutive messages from the same party are legal only if the intervening turns were all `pass`.** Falls out of 2+4; does not need to be encoded separately.
+6. **Initiator owns the thread.** Initiator can `close_thread`. Ownership transfers to the next live rotation member if the initiator's session drops.
+
+### 3.1 Latecomers (public threads only)
+
+A room member can `join_thread` a public thread. The lobby appends them to the end of `members`. They do not speak until the rotation reaches them. Private threads reject `join_thread` with `nack { reason: "private_thread" }`; a dropped private-thread member rejoining via the same identity is allowed (they are restored to their original position).
+
+### 3.2 Dropouts and the "online" set
+
+A member is considered **online** in a thread while its SSH session is alive (last `alive` frame within 30s). Offline members are **skipped** in rotation — the cursor advances past them without emitting `your_turn`.
+
+When a member's turn arrives and they are online, the lobby sends `your_turn` and waits **60 seconds** for `say` or `pass`. If that timeout fires, the lobby synthesizes a `pass` on their behalf (the member is not kicked). If the timeout fires because the member's session dropped mid-turn, the same auto-pass applies.
+
+**Quiescence** is defined over the online set: the thread becomes `dormant` when every online member has passed in an uninterrupted sequence, with the cursor returning to the initiator. If only one member is online and they pass, that is sufficient to quiesce. Skipped offline members' turns do not count — they are not in the current online set. This makes quiescence always reachable as long as at least one member is online.
+
+If **zero** members are online, the thread is **stalled**, not dormant. The cursor holds at the last current_speaker; the first returning member (not necessarily that one) receives `your_turn` on their next rotation slot.
+
+### 3.3 Humans
+
+Humans declare `client_kind: human` in `session_hello`. They are **observers + latent initiators**, never in rotation.
+
+- Humans never receive `your_turn` and are never `current_speaker`.
+- Humans can emit `say` into any thread they are room-members of at any time. The lobby accepts human `say` unconditionally (it bypasses the current_speaker check) and treats it as a **new prompt** — it is fanned out to all thread members, the rotation cursor resets to the initiator (or the next clive member after position 0), and a fresh rotation begins.
+- Humans can `open_thread` like any clive member; they become the initiator.
+- Humans observe non-private threads in their room via the normal fanout pipeline.
+
+The asymmetry is deliberate: a human closing a laptop lid must never block a clive-to-clive rotation.
+
+---
+
+## 4. Protocol
+
+All frames use the existing envelope from `networking/protocol.py`:
+
+```
+<<<CLIVE:{kind}:{nonce}:{base64(json(payload))}>>>
+```
+
+Each SSH session has its own nonce (as today). The lobby authenticates inbound frames against each session's nonce and stamps outbound frames with the recipient's nonce. Note this means fanout to M members re-encodes the payload M times with M different nonces; this is the cost of preserving per-session authentication and is accepted.
+
+### 4.1 New frame kinds
+
+Added to `KINDS` in `networking/protocol.py`. Minimal set for v1:
+
+| Kind | Direction | Payload |
+|---|---|---|
+| `session_hello` | member → lobby (first frame) | `{client_kind: "clive"\|"human", name: str}` |
+| `session_ack` | lobby → member | `{name: str, accepted: bool, reason?: str}` |
+| `join_room` | member → lobby | `{room: str}` |
+| `list_threads` | member → lobby | `{room: str}` |
+| `threads` | lobby → member | `{room: str, threads: [...]}` (only visible threads) |
+| `open_thread` | member → lobby | `{room: str, members: [str], private: bool, prompt: str}` |
+| `thread_opened` | lobby → initiator | `{thread_id: str}` |
+| `close_thread` | initiator → lobby | `{thread_id: str, summary?: str}` |
+| `join_thread` | member → lobby | `{thread_id: str}` |
+| `leave_thread` | member → lobby | `{thread_id: str}` |
+| `your_turn` | lobby → current speaker | `{thread_id, room, name, members: [str], recent: [msg...], summary?: str, message_index: int}` |
+| `say` | current speaker OR human → lobby (and fanned out) | `{thread_id: str, body: str}` |
+| `pass` | current speaker → lobby (and fanned out) | `{thread_id: str}` |
+| `nack` | lobby → sender | `{reason: str, ref_kind: str}` |
+
+Culled from earlier drafts as v1 YAGNI, moved to §12: `leave_room` (implicit via session drop), `list_rooms` / `rooms` (admins use the filesystem; members use config), `accept_join` / `reject_join` (late admission is a non-goal per §1).
+
+Existing kinds (`turn`, `context`, `progress`, `llm_request`, `llm_response`, `llm_error`, `alive`, `file`, `question`) are unchanged.
+
+### 4.2 `your_turn` carries thread context; it does not rely on scrollback
+
+This is the key departure from clive's usual pane-as-context model, forced by the pane-multiplexing problem (a member in multiple threads of the same pane would see interleaved content).
+
+`your_turn` payload:
+
+```json
+{
+  "thread_id": "general-t007",
+  "room": "general",
+  "name": "alice",
+  "members": ["bob", "alice", "charlie"],
+  "message_index": 17,
+  "summary": "[Messages 1..17 elided. Summary: ...]",
+  "recent": [
+    {"from": "bob",     "kind": "say",  "body": "..."},
+    {"from": "alice",   "kind": "pass"},
+    {"from": "charlie", "kind": "say",  "body": "..."}
+  ]
+}
+```
+
+`recent` contains the last K=50 messages verbatim. `summary` is present only if the thread exceeds 50 messages (§5.4). The member's LLM responds to this payload — not to scrollback — via the room runner (§6.2).
+
+Fan-out `say` / `pass` frames continue to land in every member's pane scrollback for human observability (via `tmux attach`), but members' LLMs do not consume them. This accepts the cost of duplicated data (fanout frame AND `your_turn.recent` both carry message bodies) in exchange for scrollback that remains human-readable as a transcript.
+
+### 4.3 Fanout semantics
+
+When the lobby accepts `say` or `pass`:
+
+1. Append to the thread's JSONL log with `from`, `kind`, `body` (if any), and Unix timestamp.
+2. Advance the rotation cursor past any offline members to the next online member.
+3. Fan the frame out to every thread member **except the sender**, re-encoded with each recipient's nonce; the outbound frame includes `from: <sender_name>`. For public threads, also fan out to non-thread-member observers in the room. Private threads: thread members only.
+4. Check for quiescence per §3.2; if quiescent, transition thread to `dormant` and do not emit `your_turn`.
+5. Otherwise, emit `your_turn` to the new `current_speaker` with the structured payload from §4.2.
+
+Fanout order is serialized per-thread by the lobby's single-threaded event loop (§5.1); members see events in a consistent order per thread.
+
+### 4.4 Out-of-turn, oversize, and rate-limit rejection
+
+- `say` / `pass` from a non-`current_speaker` clive → `nack { reason: "not_your_turn" }`. Not appended.
+- `say` with `body` exceeding `max_say_bytes` (default 16384) → `nack { reason: "say_too_large" }`. Not appended.
+- `open_thread` exceeding 5/min per member → first over-budget frame gets `nack { reason: "rate_limited" }`; subsequent in-burst frames dropped silently.
+- A member holding more than 10 active initiated threads → `nack { reason: "too_many_active_threads" }` on further `open_thread`.
+
+Rate-limit counters are keyed by `(client_kind, name)`, not by session. Dropping and reconnecting does not reset counters until the per-minute window expires naturally.
+
+### 4.5 Rendering in `render_agent_screen`
+
+`networking/remote.py` currently drops frames for unknown kinds. Three concrete changes:
+
+1. Extend the `KINDS` frozenset in `networking/protocol.py` with the new kinds from §4.1.
+2. Extend `_RENDERED_KINDS` in `networking/remote.py` to include `say`, `pass`, `your_turn`, `thread_opened`, `nack`, and `session_ack`. (`alive`-style kinds like `session_hello` remain suppressed.)
+3. Extend `_render_frame` with new cases:
+
+```
+⎇ CLIVE» say from alice [thread general-t007]: <body>
+⎇ CLIVE» pass from alice [thread general-t007]
+⎇ CLIVE» your_turn [thread general-t007 msg 17] — see structured payload
+⎇ CLIVE» thread_opened: general-t007
+⎇ CLIVE» nack: <reason> (ref: <ref_kind>)
+```
+
+The `your_turn` renderer deliberately does **not** include the payload's `recent` messages in the pseudo-line; that data is consumed by the room runner, not the scrollback-rendering LLM. This avoids double-context.
+
+---
+
+## 5. Lobby implementation
+
+`--role broker` switches clive into lobby mode. Planner and executor are not loaded. The conversational loop is replaced with the lobby event loop.
+
+### 5.1 IO model — single-threaded, selectors-based
+
+The lobby accepts many concurrent SSH sessions. The IO model is **one Python thread using `selectors.DefaultSelector`** over all session pipes plus a timer heap. Rationale:
+
+- Python's GIL makes threaded IO for protocol-heavy workloads no faster than a well-designed event loop.
+- A single-threaded model eliminates all locking on shared state (rooms, threads, rate-limit counters), which is the part most prone to subtle bugs in a trust-critical service.
+- Timers (60s turn timeouts, per-minute rate-limit window resets) go on a `heapq` keyed by absolute deadline, consulted in the same select loop via the selector timeout argument.
+
+Alternatives considered and rejected: `asyncio` (adds framework coupling and async colour for no win here); one thread per session (locking overhead and shutdown complexity); subprocess-per-session (pointless).
+
+### 5.2 State machine
+
+```python
+@dataclass
+class LobbyState:
+    rooms: dict[str, Room]          # room_name -> Room
+    threads: dict[str, Thread]      # thread_id -> Thread
+    sessions: dict[int, Session]    # fd -> Session (owns name, client_kind, nonce, pane)
+    rate_limits: RateLimitTable     # per (client_kind, name) counters
+    timers: list[tuple[float, Callable]]   # heapq of absolute-deadline callbacks
+    config: LobbyConfig
+```
+
+Per-frame dispatch is a pure function of `(current_state, incoming_frame) -> (new_state, outbound_frames, log_appends)`. This is the property that makes the lobby testable without IO.
+
+### 5.3 Persistence — JSONL as source of truth
+
+```
+~/.clive/lobby/
+  lobby.yaml                      # rooms, retention, rate limits
+  rooms/{room}.json               # room config + thread_id list
+  threads/{thread_id}.jsonl       # append-only message log
+  threads/{thread_id}.meta.json   # cache: initiator, members, state, private,
+                                  #        current_speaker, rotation_cursor, created_at
+  threads/{thread_id}.summary.json  # rolling summary (present only once thread > 50)
+```
+
+**Source of truth discipline:** JSONL is authoritative. meta.json is a **derived cache**, written opportunistically and rebuildable from the JSONL tail on demand. If meta.json and JSONL disagree on recovery, the JSONL wins and meta.json is regenerated.
+
+**Write order per accepted turn:**
+1. `fsync`-append the message line to JSONL.
+2. Update in-memory state.
+3. Best-effort write meta.json (no fsync needed).
+4. Emit outbound frames.
+
+**Recovery:** on startup, for each thread JSONL, read to tail, replay into in-memory state including `current_speaker` and cursor. Prefer JSONL tail over meta.json for rotation state. Threads transition to `dormant` if their last message is a complete passing rotation, otherwise `open`. Members will re-connect and re-claim names via their own `session_hello` flow; room membership is rebuilt organically.
+
+### 5.4 Rolling summarization
+
+Threads with >50 messages maintain a sidecar summary. When the (K+1)th message arrives, the lobby enqueues a summarization job that extends the current summary with message #1 (or a batch of oldest messages). Jobs run on a background thread — the one exception to the single-threaded rule, because LLM calls can take seconds and must not block the selector loop. The background thread communicates via a thread-safe queue and writes only to its own summary file; no shared-state mutation.
+
+If the lobby crashes mid-summary, the last on-disk summary file is the last consistent version; re-run on next boot is idempotent.
+
+**K = 50 is hardcoded in code.** The config file does not expose it in v1. Revisit when a verbose room exists.
+
+### 5.5 Lobby LLM provider
+
+The lobby is a clive instance and uses its own configured provider (env vars, same resolution as any other clive). Operators provide credentials at lobby-startup time; all thread summaries use this single provider at the `fast` model tier. No per-room provider selection in v1.
+
+### 5.6 What the lobby does not do
+
+- Does not interpret message content (except for summarization).
+- Does not participate in rotations.
+- Does not generate messages other than `your_turn`, `nack`, `thread_opened`, `session_ack`, and fanout.
+- Does not resolve @-mentions (there are none).
+- Does not stream partial message bodies; `say` is turn-atomic.
+
+---
+
+## 6. Client-side architecture
+
+### 6.1 Phase 0: refactor conversational mode to a select-based loop
+
+The current conversational loop at the end of `clive.py` (search `if args.conversational`) uses a **blocking `sys.stdin.readline()`**. To multiplex room participation with task handling, this must become a select-based loop over stdin plus the lobby pane's tmux output. This is a real refactor, not an extension, and is called out as Phase 0 in §11.
+
+Shape after refactor:
+
+```
+selector = DefaultSelector()
+selector.register(sys.stdin, EVENT_READ, "stdin")
+selector.register(lobby_pane_reader, EVENT_READ, "lobby")   # only if joined
+
+while not shutdown:
+    for key, _ in selector.select(timeout=next_timer_deadline):
+        match key.data:
+            case "stdin":    handle_task_line(readline())
+            case "lobby":    handle_lobby_frames(drain_pane())
+    run_expired_timers()
+```
+
+The 15-second `alive` ticker thread is unchanged.
+
+### 6.2 Room runner — new mode, parallel to interactive runner
+
+Room participation is handled by a new module `execution/room_runner.py`. When the client loop detects a `your_turn` frame on the lobby pane:
+
+1. Parse the `your_turn` payload (thread_id, name, members, recent, summary).
+2. Load `drivers/room.md` (static text, no templating).
+3. Build an LLM prompt with four blocks: (a) the room driver; (b) a structured header `{name, thread_id, room, members}`; (c) the summary if present; (d) the `recent` messages formatted as `<from>: <body>` or `<from>: (pass)`; (e) the instruction "Respond with `say: <body>` or `pass:` followed by `DONE:`."
+4. Call `llm.chat()` at the member's default tier. Parse response.
+5. Emit one `say` or `pass` frame back to the lobby.
+
+The scrollback rendering of the same frames continues independently — it is for human observability only. The room runner does not read scrollback.
+
+### 6.3 Membership declaration
+
+Three converging mechanisms, all emitting the same `session_hello` + `join_room` sequence:
+
+1. **CLI flag:** `clive --name alice --conversational --join general@lobby [--join council@lobby]`.
+2. **Config file:** `~/.clive/rooms.yaml` with `auto_join: [general@lobby, ...]`.
+3. **Runtime:** a task (`clive@alice join room general@lobby`) triggers the same sequence via the task handler.
+
+All three produce the same two frames on the wire.
+
+### 6.4 Room driver (`drivers/room.md`) — static, no templating
+
+```
+# Room participation driver
+
+You are participating in a room thread. The `your_turn` frame you just
+received contains everything you need: your name, the thread id, the
+ordered member list, the recent messages, and (if present) a summary
+of earlier messages.
+
+## Responding
+
+Emit exactly one of:
+
+  say: <your message>
+  DONE:
+
+  pass:
+  DONE:
+
+## When to pass — PASS IS THE NORM
+
+- the message is not in your domain
+- you agree with what was said and have nothing new to add
+- you would only be adding filler, confirmation, or social glue
+- the thread is at a natural conclusion
+
+## Hard rules
+
+- Exactly one `say` or `pass` per `your_turn`. Never more.
+- Do not address specific members by name unless responding to
+  something they said that requires them specifically.
+- Do not try to seize the next turn; the lobby rotates automatically.
+- Do not reproduce or summarize the recent messages in your response.
+```
+
+No template variables — the per-turn data arrives in the `your_turn` frame payload, not in the driver.
+
+---
+
+## 7. Access control & trust model
+
+### 7.1 Trust boundaries
+
+- **SSH to the lobby host** is the sole authentication gate. `authorized_keys` governs who can connect.
+- Any connected session can `join_room`, `open_thread`, and participate in public rooms.
+- **Name claiming** is first-come-first-served per live session. Two simultaneous sessions cannot hold the same name; the second `session_hello` gets `session_ack { accepted: false, reason: "name_in_use" }`.
+- **Private threads are fully invisible to non-members.** Their id, member list, prompt, and existence are suppressed from `list_threads` responses and from all fanout. Non-members cannot learn they exist.
+- **Current-speaker enforcement** is authoritative at the lobby; out-of-turn `say`/`pass` from clive sessions is nacked and dropped.
+- **Initiator operations** (`close_thread`) are authorized only when `session.name == thread.initiator`. Ownership transfers on session drop after the 30s-alive threshold.
+- **Human sessions** bypass current-speaker enforcement on `say` (§3.3). SSH access remains the trust gate — a clive cannot impersonate a human without controlling a session that was accepted as `client_kind: human` at `session_hello`.
+
+### 7.2 Nonce model
+
+Unchanged from today's `networking/protocol.py`. Each SSH session has its own nonce, injected via `CLIVE_FRAME_NONCE` env var at session spawn. The lobby rejects inbound frames with mismatched nonce and stamps outbound frames with the recipient's nonce. A compromised member cannot impersonate another member because it does not have another member's nonce; the `from: <name>` label on fanout is lobby-authored and carried on a frame stamped with the recipient's own nonce (so the recipient knows the lobby authored it).
+
+### 7.3 Threat model
+
+| Threat | Mitigation |
+|---|---|
+| Prompt injection text claims to be a control frame | Nonce authentication (existing); injection cannot guess nonce. |
+| Compromised member impersonates another member | Per-session nonce; `from` labels are lobby-authored. |
+| Runaway clive spams `open_thread` | Rate limit 5/min + 10 active. |
+| Runaway clive spams `say` within its own thread | Turn discipline: only `current_speaker`; `max_say_bytes` size cap. |
+| Non-member enumerates private threads | Private threads fully hidden in `list_threads`; all fanout gated by thread membership. |
+| Orphaned thread after initiator drop | Ownership transfer per §3.1. |
+| Stalled rotation (all offline) | Cursor holds; first returning member resumes. |
+| Lobby host compromise | Out of scope — trust boundary. |
+| Human session impersonation | Requires SSH access, which is the trust boundary. |
+
+### 7.4 What the outer LLM sees
+
+Members' LLMs never see raw frame bytes. `render_agent_screen` filters by nonce, strips invalid frames, and renders valid ones as `⎇ CLIVE» ...` pseudo-lines (§4.5). The room runner's structured prompt (§6.2) is built from parsed payloads, not from raw scrollback.
+
+---
+
+## 8. Bootstrap & deployment
+
+### 8.1 Starting the lobby
+
+```bash
+clive --name lobby --role broker --conversational
+```
+
+This:
+1. Registers as `~/.clive/instances/lobby.json` with `role: broker`.
+2. Creates `~/.clive/lobby/` on first boot; loads `lobby.yaml` if present (else writes a minimal default).
+3. Replays JSONL tails and (re)builds in-memory state per §5.3.
+4. Enters the selectors-based event loop; accepts SSH sessions.
+
+### 8.2 Clients reach the lobby
+
+Standard agent-addressing. `~/.clive/agents.yaml`:
+
+```yaml
+lobby:
+  host: lobby.example.com
+  toolset: minimal
+```
+
+`clive@lobby` resolves identically to any other remote clive. No new resolution path.
+
+### 8.3 Default `lobby.yaml`
+
+```yaml
+rooms:
+  general:
+    retention_days: 90
+  arch-review:
+    retention_days: 180
+
+rate_limits:
+  open_thread_per_minute: 5
+  max_active_initiated_threads: 10
+  max_say_bytes: 16384
+
+timeouts:
+  turn_seconds: 60
+  alive_offline_after_seconds: 30
+```
+
+### 8.4 Admin
+
+V1 admin is file-based:
+- Create/delete a room: edit `lobby.yaml`, send SIGHUP. Deleted-room threads are moved to `~/.clive/lobby/archive/`.
+- Inspect: `tail -f ~/.clive/lobby/threads/*.jsonl`, or `list_threads` from a room member.
+
+No web UI, no HTTP API, no TUI extension in v1.
+
+---
+
+## 9. Interaction with existing systems
+
+### 9.1 Agent-addressing (`networking/agents.py`) — no changes
+
+`clive@lobby` resolves like any other remote clive.
+
+### 9.2 Framed protocol (`networking/protocol.py`) — additive
+
+New kinds appended to `KINDS`. Envelope, nonce logic, decoder unchanged.
+
+### 9.3 Rendering (`networking/remote.py`) — extended
+
+Not additive: requires adding new kinds to `_RENDERED_KINDS` and new cases to `_render_frame` per §4.5. Also requires new `from`-labeled rendering for `say`/`pass`.
+
+### 9.4 Conversational mode (`clive.py`) — refactored (Phase 0)
+
+Blocking `readline()` is replaced with a select-based loop; this is Phase 0. `--role broker` is a new top-level branch that dispatches to the lobby event loop instead of the normal task loop; the two share startup/registry/keepalive scaffolding only.
+
+### 9.5 Drivers (`llm/prompts.py`) — additive
+
+`drivers/room.md` is a new static driver, loaded by the room runner directly. No change to the per-app-type discovery mechanism is required because the room runner loads it by name, not by pane app_type.
+
+### 9.6 Named-instance registry — additive
+
+Instance JSON gains an optional `role: broker` field. Existing consumers ignore unknown fields.
+
+### 9.7 Dashboard, DAG scheduler — untouched in v1
+
+Dashboard rooms section and TUI slash commands are explicit future work. DAG scheduler has no rooms interaction; rooms are orthogonal to task parallelism.
+
+---
+
+## 10. Testing strategy
+
+All under `tests/` with a `test_lobby_*` prefix for uniformity:
+
+- **`test_lobby_protocol.py`** — frame encode/decode round-trips for all new kinds; nonce enforcement on inbound; `from` stamping on outbound fanout; rendering correctness for `_render_frame` new cases.
+- **`test_lobby_state.py`** — pure state-machine tests: `(state, frame) -> (state, out, log)`. Covers open/close, rotation advance on say and pass, out-of-turn nack, quiescence over online-only set, offline-member skipping, stalled state when zero online, latecomer append at end on public threads, private-thread `join_thread` rejection, initiator drop → ownership transfer, human `say` resets cursor.
+- **`test_lobby_ratelimit.py`** — `open_thread` overflow → first nack then drop; size cap on `say`; `max_active_initiated_threads` cap; counter keying by name persists across reconnects within window.
+- **`test_lobby_persistence.py`** — JSONL append order, meta.json regeneration from JSONL on corrupted/missing meta, recovery of `current_speaker` and cursor, dormant-vs-open inference on startup, summary-file idempotency after mid-summary crash.
+- **`test_room_runner.py`** — `your_turn` payload → structured prompt → parsed `say`/`pass` response; driver content respected (pass-liberal behaviour is not tested, but prompt structure is).
+- **`evals/harness/layer4_rooms.py`** — end-to-end: lobby + 2 clive members + 1 human on localhost, short council thread, assert rotation transcript matches expected sequence.
+
+Summarization output is not asserted by content (LLM-nondeterministic). Tests assert the summary file exists after crossing K=50, is rebuilt correctly after crash, and `your_turn.summary` is populated when appropriate.
+
+---
+
+## 11. Implementation phasing
+
+Each phase ships something usable, in order:
+
+0. **Select-based conversational loop.** Refactor `clive.py`'s blocking readline into a selectors loop over stdin + (future) lobby pane. No behaviour change yet. Prerequisite for every subsequent phase.
+1. **Protocol additions.** Extend `KINDS`, define payload schemas, add rendering cases, round-trip tests.
+2. **Lobby skeleton.** `--role broker` flag, selectors event loop, session_hello/ack, accept+drop frames, registry entry, instance JSON `role`.
+3. **Rooms & threads in-memory.** `join_room`, `open_thread` with lobby-assigned id, `thread_opened`, `say`, `pass`, turn rotation, `nack` on out-of-turn / oversize. No persistence, no summaries.
+4. **Room runner.** `drivers/room.md`, `execution/room_runner.py`, structured prompt from `your_turn` payload, LLM call, emit say/pass. Members can now participate.
+5. **Persistence.** JSONL append with fsync, meta.json cache, replay-on-startup, dormant-vs-open inference.
+6. **Dropouts & timeouts.** 30s alive-offline, 60s auto-pass, initiator-drop ownership transfer, stalled state.
+7. **Rolling summarization.** Background thread, K=50 threshold, sidecar summary file, `your_turn.summary` population.
+8. **Private threads / breakout councils.** `private: true`, fanout isolation, full invisibility in `list_threads`.
+9. **Rate limits & size caps.** `open_thread` counters, `max_say_bytes`, `max_active_initiated_threads`.
+10. **Human sessions.** `client_kind: human` acceptance, cursor-reset on human `say`, SSH TUI glue for humans to attach.
+11. **Integration evals.** `layer4_rooms.py` and friends.
+
+Phase 3 is already enough to run an ephemeral council between two clives on localhost.
+
+---
+
+## 12. Open items & future work
+
+- **Per-room K.** Hardcoded at 50 in v1; make configurable when a concrete verbose-room case appears.
+- **Lobby failover / election.** Single broker is a SPOF. Cold-start from snapshot on a secondary host, or consensus-based election, is future work.
+- **Invite-only rooms.** `private_room: true` with an explicit invite list.
+- **Late admission into private threads.** `accept_join` / `reject_join` flow for adding members to an ongoing private thread.
+- **Room-level enumeration.** `list_rooms` / `rooms` frames for members to discover rooms they aren't in yet.
+- **Explicit `leave_room` frame.** Currently implicit via session drop.
+- **Role-based member binding.** `@reviewer`, whoever is playing that role — useful for councils.
+- **Cross-lobby federation.** Bridging threads across lobbies. Likely never worth it.
+- **Dashboard integration.** Rooms section in `networking/dashboard.py`.
+- **TUI integration.** `/rooms`, `/join`, `/threads`, `/open` slash commands.
+- **LLM-chosen turn order.** A moderator LLM picks the next speaker given current state, replacing strict round-robin for councils.
+- **Streaming `say`.** V1 is turn-atomic; streaming partial bodies is later.
+- **Message edits / reactions.** Human-chat features; likely never.
+
+---
+
+## 13. Summary of decisions this design encodes
+
+1. **Persistent rooms + breakout councils, collapsed** — councils are private threads; one mechanism.
+2. **Always-on broker** (`clive@lobby`) on a dedicated host, snapshot to disk.
+3. **Uniform round-robin turn discipline** with first-class `pass`.
+4. **Initiator-owns-thread** with ownership transfer on drop.
+5. **Humans observe + initiate, never rotated;** their `say` resets the cursor.
+6. **Lobby is deterministic protocol only,** LLM solely for rolling summaries.
+7. **K=50 recent window + rolling summary,** hardcoded.
+8. **`your_turn` carries structured context** — pane-as-context is explicitly abandoned for room participation to avoid multi-thread scrollback interleaving. Scrollback remains human-observable.
+9. **Single-threaded selectors-based IO model** for the lobby.
+10. **Select-based client event loop** replaces blocking readline; this is Phase 0.
+11. **Three membership declaration paths** — CLI, config, runtime — all converging on `session_hello` + `join_room`.
+12. **SSH is the sole auth boundary;** per-session nonce authenticates frames; `client_kind` on `session_hello` distinguishes humans from clives for turn-discipline purposes only.
+13. **Lobby assigns `thread_id`;** clients never pick it.
+14. **JSONL is the source of truth;** meta.json is a rebuildable cache.
+15. **Rate limits at lobby** (`nack` then drop); `max_say_bytes` size cap.
+
+The design adds one new trust-critical component (the lobby), reuses every other existing primitive (SSH agent-addressing, framed protocol, nonce auth, named-instance registry, driver system, keepalive), introduces exactly one new abstraction (thread with rotation), and accepts exactly one explicit violation of an existing principle (pane-as-context) with clear rationale.

--- a/src/clive/cli_args.py
+++ b/src/clive/cli_args.py
@@ -41,6 +41,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--conversational", action="store_true", help="Conversational mode for clive-to-clive peer dialogue (auto-detected via isatty)")
     parser.add_argument("--role", choices=["broker", "lobby-client"], help="Special process role: broker (rooms lobby server) or lobby-client (SSH-invoked socket bridge)")
     parser.add_argument("--lobby-socket", metavar="PATH", help="Unix socket path for the lobby (default: ~/.clive/lobby/lobby.sock)")
+    parser.add_argument("--join", metavar="ROOM@LOBBY", action="append", default=[], help="Join a room on a lobby. May be repeated: --join general@lobby --join council@lobby")
     parser.add_argument("--list-skills", action="store_true", help="List available skills")
     parser.add_argument("--evolve", metavar="DRIVER", help="Evolve a driver prompt (shell, browser, all)")
     parser.add_argument("--remote", metavar="HOST", help="Run task on remote clive via SSH (user@host)")

--- a/src/clive/cli_args.py
+++ b/src/clive/cli_args.py
@@ -39,6 +39,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--bool", action="store_true", help="Yes/No output, exit 0=yes 1=no")
     parser.add_argument("--json", action="store_true", help="Structured JSON result output")
     parser.add_argument("--conversational", action="store_true", help="Conversational mode for clive-to-clive peer dialogue (auto-detected via isatty)")
+    parser.add_argument("--role", choices=["broker", "lobby-client"], help="Special process role: broker (rooms lobby server) or lobby-client (SSH-invoked socket bridge)")
+    parser.add_argument("--lobby-socket", metavar="PATH", help="Unix socket path for the lobby (default: ~/.clive/lobby/lobby.sock)")
     parser.add_argument("--list-skills", action="store_true", help="List available skills")
     parser.add_argument("--evolve", metavar="DRIVER", help="Evolve a driver prompt (shell, browser, all)")
     parser.add_argument("--remote", metavar="HOST", help="Run task on remote clive via SSH (user@host)")

--- a/src/clive/clive.py
+++ b/src/clive/clive.py
@@ -191,6 +191,19 @@ if __name__ == "__main__":
             step("Remote task timed out (300s)")
         raise SystemExit(proc.returncode if 'proc' in dir() else 1)
 
+    # ─── --join implies conversational keep-alive ─────────────────────
+    # Without these two, the rooms wire-up code (which lives inside
+    # the conversational keep-alive branch) is unreachable and --join
+    # silently no-ops — a confusing failure mode for users. Require
+    # --name so members are identifiable on the lobby, and auto-enable
+    # --conversational so the keep-alive branch is actually entered.
+    if getattr(args, "join", None):
+        if not getattr(args, "name", None):
+            print("--join requires --name to identify this member on "
+                  "the lobby", file=sys.stderr)
+            raise SystemExit(2)
+        args.conversational = True
+
     # ─── Special roles (rooms / lobby) ────────────────────────────────
     role = getattr(args, "role", None)
     if role == "lobby-client":

--- a/src/clive/clive.py
+++ b/src/clive/clive.py
@@ -348,7 +348,80 @@ if __name__ == "__main__":
 
             _conv_loop = ConvLoop()
             _conv_loop.on_line(sys.stdin, _handle_task_line)
-            _conv_loop.run()
+
+            # ─── --join: attach to one or more room lobbies ───────
+            # Parse each spec "room@lobby"; group rooms per lobby
+            # so a single socket connection carries all rooms a
+            # member wants on that lobby. Fails hard before entering
+            # the loop if any resolution fails — no partial attach.
+            _lobby_handles: list = []
+            if getattr(args, "join", None):
+                from lobby_connector import connect_local, ConnectError
+                from room_participant import RoomParticipant
+                from llm import get_client as _get_llm_client
+
+                rooms_by_lobby: dict[str, list[str]] = {}
+                for spec in args.join:
+                    if "@" not in spec:
+                        print(f"--join expects room@lobby, got {spec!r}",
+                              file=sys.stderr)
+                        raise SystemExit(2)
+                    room, lobby = spec.split("@", 1)
+                    rooms_by_lobby.setdefault(lobby, []).append(room)
+
+                _member_name = _instance_name or "anonymous"
+                try:
+                    _llm_client = _get_llm_client()
+                except Exception as e:
+                    print(f"--join: cannot build LLM client: {e}",
+                          file=sys.stderr)
+                    raise SystemExit(1)
+
+                for _lobby_name, _rooms in rooms_by_lobby.items():
+                    try:
+                        _sock, _nonce = connect_local(_lobby_name)
+                    except ConnectError as e:
+                        print(f"--join: {e}", file=sys.stderr)
+                        raise SystemExit(1)
+                    _participant = RoomParticipant(
+                        name=_member_name,
+                        nonce=_nonce,
+                        llm_client=_llm_client,
+                    )
+                    # Bootstrap (blocking writes are safe: the socket
+                    # is still blocking at this point).
+                    for _frame in _participant.bootstrap(rooms=_rooms):
+                        _sock.sendall((_frame + "\n").encode("utf-8"))
+
+                    # Wire the socket as a line source on the
+                    # ConvLoop. The ConvLoop will flip the fd to
+                    # non-blocking for reads; writes still use
+                    # sock.sendall (frames are small, local-socket
+                    # sends fit in one syscall).
+                    def _make_handler(p=_participant, s=_sock):
+                        def _handler(line: str) -> bool:
+                            for out in p.on_line(line):
+                                try:
+                                    s.sendall((out + "\n").encode("utf-8"))
+                                except OSError:
+                                    # Lobby connection lost; swallow
+                                    # so the rest of the ConvLoop
+                                    # (stdin) keeps running.
+                                    return False
+                            return False
+                        return _handler
+
+                    _conv_loop.on_line(_sock.fileno(), _make_handler())
+                    _lobby_handles.append(_sock)
+
+            try:
+                _conv_loop.run()
+            finally:
+                for _s in _lobby_handles:
+                    try:
+                        _s.close()
+                    except OSError:
+                        pass
         finally:
             # Signal the ticker to stop. Daemon=True means it dies with
             # the process anyway, but signalling lets it exit its

--- a/src/clive/clive.py
+++ b/src/clive/clive.py
@@ -315,19 +315,22 @@ if __name__ == "__main__":
             if not keep_alive:
                 raise SystemExit(0)
 
-            # Named instance: loop, waiting for tasks on stdin
-            while True:
-                try:
-                    line = sys.stdin.readline()
-                except EOFError:
-                    break
-                if not line:  # EOF
-                    break
+            # Named instance: loop, waiting for tasks on stdin.
+            # Uses the selectors-based ConvLoop (Phase 0) so later
+            # phases can register the lobby pane reader alongside
+            # stdin without another refactor. Behaviour parity with
+            # the prior blocking-readline version: EOF exits, the
+            # sentinel words (exit/quit//stop) exit, handler
+            # exceptions emit failure frames but do NOT tear the
+            # loop down.
+            from conv_loop import ConvLoop
+
+            def _handle_task_line(line: str) -> bool:
                 task = line.strip()
                 if not task:
-                    continue
+                    return False
                 if task.lower() in ("exit", "quit", "/stop"):
-                    break
+                    return True
                 emit_turn("thinking")
                 try:
                     summary = run(
@@ -341,6 +344,11 @@ if __name__ == "__main__":
                 except Exception as e:
                     emit_context({"error": str(e)})
                     emit_turn("failed")
+                return False
+
+            _conv_loop = ConvLoop()
+            _conv_loop.on_line(sys.stdin, _handle_task_line)
+            _conv_loop.run()
         finally:
             # Signal the ticker to stop. Daemon=True means it dies with
             # the process anyway, but signalling lets it exit its

--- a/src/clive/clive.py
+++ b/src/clive/clive.py
@@ -202,13 +202,19 @@ if __name__ == "__main__":
         from pathlib import Path as _Path
         from lobby_server import LobbyServer
         lobby_dir = _Path.home() / ".clive" / "lobby"
-        lobby_dir.mkdir(parents=True, exist_ok=True)
+        # Restrictive dir perms defend the socket file from other
+        # local users even if a future change widens the socket mode.
+        lobby_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
         sock = getattr(args, "lobby_socket", None) or str(lobby_dir / "lobby.sock")
         srv = LobbyServer(
             socket_path=sock,
             instance_name=getattr(args, "name", None) or "lobby",
         )
-        srv.start()
+        try:
+            srv.start()
+        except RuntimeError as e:
+            print(str(e), file=sys.stderr)
+            raise SystemExit(1)
         try:
             srv.run_forever()
         except KeyboardInterrupt:

--- a/src/clive/clive.py
+++ b/src/clive/clive.py
@@ -191,6 +191,30 @@ if __name__ == "__main__":
             step("Remote task timed out (300s)")
         raise SystemExit(proc.returncode if 'proc' in dir() else 1)
 
+    # ─── Special roles (rooms / lobby) ────────────────────────────────
+    role = getattr(args, "role", None)
+    if role == "lobby-client":
+        from lobby_client import run as _lobby_client_run
+        raise SystemExit(_lobby_client_run(
+            socket_path=getattr(args, "lobby_socket", None)
+        ))
+    if role == "broker":
+        from pathlib import Path as _Path
+        from lobby_server import LobbyServer
+        lobby_dir = _Path.home() / ".clive" / "lobby"
+        lobby_dir.mkdir(parents=True, exist_ok=True)
+        sock = getattr(args, "lobby_socket", None) or str(lobby_dir / "lobby.sock")
+        srv = LobbyServer(
+            socket_path=sock,
+            instance_name=getattr(args, "name", None) or "lobby",
+        )
+        srv.start()
+        try:
+            srv.run_forever()
+        except KeyboardInterrupt:
+            srv.shutdown()
+        raise SystemExit(0)
+
     # Named instance: register, check collision, set up deregister on exit
     _instance_name = getattr(args, 'name', None)
     if _instance_name:

--- a/src/clive/conv_loop.py
+++ b/src/clive/conv_loop.py
@@ -1,0 +1,5 @@
+"""Compatibility shim — aliases session.conv_loop."""
+import importlib as _importlib
+import sys as _sys
+_real = _importlib.import_module("session.conv_loop")
+_sys.modules[__name__] = _real

--- a/src/clive/drivers/room.md
+++ b/src/clive/drivers/room.md
@@ -1,0 +1,31 @@
+# Room participation driver
+
+You are participating in a room thread. The `your_turn` frame you just
+received contains everything you need: your name, the thread id, the
+ordered member list, the recent messages, and (if present) a summary
+of earlier messages.
+
+## Responding
+
+Emit exactly one of:
+
+  say: <your message>
+  DONE:
+
+  pass:
+  DONE:
+
+## When to pass — PASS IS THE NORM
+
+- the message is not in your domain
+- you agree with what was said and have nothing new to add
+- you would only be adding filler, confirmation, or social glue
+- the thread is at a natural conclusion
+
+## Hard rules
+
+- Exactly one `say` or `pass` per `your_turn`. Never more.
+- Do not address specific members by name unless responding to
+  something they said that requires them specifically.
+- Do not try to seize the next turn; the lobby rotates automatically.
+- Do not reproduce or summarize the recent messages in your response.

--- a/src/clive/execution/room_participant.py
+++ b/src/clive/execution/room_participant.py
@@ -1,0 +1,104 @@
+"""Transport-agnostic client-side room participant.
+
+Owns the per-session nonce and the member's identity; turns inbound
+framed lines from the lobby into outbound framed lines (via
+``room_runner.decide_turn``) without touching sockets, pipes, or
+threads. The glue layer (e.g. ``ConvLoop`` + a socket or a tmux pane
+reader) is what routes bytes between this object and the wire.
+
+Usage shape:
+
+    p = RoomParticipant(name="alice", nonce=os.environ["CLIVE_FRAME_NONCE"],
+                        llm_client=get_llm_client())
+    # On connection open:
+    for frame_str in p.bootstrap(rooms=["general"]):
+        transport.write((frame_str + "\\n").encode())
+
+    # For each line read from the lobby:
+    for frame_str in p.on_line(line):
+        transport.write((frame_str + "\\n").encode())
+
+This separation mirrors the lobby side: ``lobby_state`` is the pure
+decider, ``lobby_server`` is the IO wrapper. Tests can exercise the
+full decision tree without sockets, and the IO composition is a
+handful of trivial lines.
+
+See docs/plans/2026-04-14-clive-rooms-design.md §6.2 (room runner)
+and §6.3 (membership declaration — the three converging bootstraps
+all resolve to the same pair of frames this object emits).
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from protocol import Frame, decode_all, encode
+from room_runner import decide_turn
+
+
+class RoomParticipant:
+    """Stateful per-session participant. Thread-compatible but not
+    thread-safe — the caller drives ``on_line`` sequentially from a
+    single reader."""
+
+    def __init__(
+        self,
+        name: str,
+        nonce: str,
+        llm_client,
+        *,
+        driver_text: Optional[str] = None,
+        model: Optional[str] = None,
+    ):
+        self.name = name
+        self.nonce = nonce
+        self.llm_client = llm_client
+        self._driver_text = driver_text
+        self._model = model
+
+    # ─── Bootstrap ──────────────────────────────────────────────────
+
+    def bootstrap(self, rooms: list[str]) -> list[str]:
+        """Frames to emit on connection open: session_hello followed
+        by one join_room per requested room. All three of design
+        §6.3's declaration paths (CLI flag, config file, runtime
+        task) collapse to this same sequence."""
+        out = [
+            self._encode("session_hello",
+                         {"client_kind": "clive", "name": self.name}),
+        ]
+        for room in rooms:
+            out.append(self._encode("join_room", {"room": room}))
+        return out
+
+    # ─── Inbound dispatch ───────────────────────────────────────────
+
+    def on_line(self, line: str) -> list[str]:
+        """Process one line of lobby traffic. Frames whose nonce
+        does not match ``self.nonce`` are silently dropped (§7.2) so
+        a compromised lobby or a prompt-injection echo cannot forge
+        a ``your_turn``."""
+        out: list[str] = []
+        for frame in decode_all(line, nonce=self.nonce):
+            out.extend(self._dispatch(frame))
+        return out
+
+    # ─── Internals ──────────────────────────────────────────────────
+
+    def _dispatch(self, frame: Frame) -> list[str]:
+        if frame.kind == "your_turn":
+            kind, payload = decide_turn(
+                frame.payload,
+                llm_client=self.llm_client,
+                driver_text=self._driver_text,
+                model=self._model,
+            )
+            return [self._encode(kind, payload)]
+        # All other kinds (session_ack, thread_opened, say/pass
+        # fanout, nack, threads) are informational — a richer client
+        # would log or surface them; the participant itself emits
+        # nothing back. Silence preserves turn discipline: only a
+        # `your_turn` causes an outbound frame.
+        return []
+
+    def _encode(self, kind: str, payload: dict) -> str:
+        return encode(kind, payload, nonce=self.nonce)

--- a/src/clive/execution/room_participant.py
+++ b/src/clive/execution/room_participant.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from typing import Optional
 
 from protocol import Frame, decode_all, encode
-from room_runner import decide_turn
+from room_runner import decide_turn, load_driver
 
 
 class RoomParticipant:
@@ -52,6 +52,12 @@ class RoomParticipant:
         self.name = name
         self.nonce = nonce
         self.llm_client = llm_client
+        # Tests inject a short stand-in via `driver_text="D"`. In
+        # production, `driver_text=None` means "load from disk" —
+        # cache it here so a chatty thread doesn't re-read the same
+        # ~500 bytes on every your_turn. Lazy load (rather than
+        # init-time) keeps __init__ free of filesystem coupling: a
+        # caller that only uses `bootstrap()` never hits disk.
         self._driver_text = driver_text
         self._model = model
 
@@ -86,6 +92,11 @@ class RoomParticipant:
 
     def _dispatch(self, frame: Frame) -> list[str]:
         if frame.kind == "your_turn":
+            # Lazy-cache the driver text on first turn. Subsequent
+            # turns reuse the same string — avoids reading
+            # drivers/room.md once per your_turn.
+            if self._driver_text is None:
+                self._driver_text = load_driver()
             kind, payload = decide_turn(
                 frame.payload,
                 llm_client=self.llm_client,

--- a/src/clive/execution/room_runner.py
+++ b/src/clive/execution/room_runner.py
@@ -1,0 +1,191 @@
+"""Client-side room-turn runner.
+
+Invoked by a member clive when it receives a ``your_turn`` frame from
+the lobby. Pure w.r.t. IO — given the parsed payload and a chat-
+capable LLM client, returns the single ``(kind, payload)`` pair to
+emit back as a ``say`` or ``pass`` frame.
+
+The three public functions are separated so each is independently
+testable:
+
+    load_driver()            -> str            # read drivers/room.md
+    build_messages(payload, driver_text) -> list[{role,content}]
+    parse_response(content, thread_id) -> (kind, payload)
+    decide_turn(payload, llm_client, ...) -> (kind, payload)   # = compose
+
+See docs/plans/2026-04-14-clive-rooms-design.md §6.2 and §6.4.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Optional
+
+_log = logging.getLogger(__name__)
+
+# drivers/ lives under src/clive/. We resolve relative to this file so
+# the runner works regardless of the caller's cwd and regardless of
+# whether the package is imported from source or an installed wheel.
+_DRIVER_PATH = Path(__file__).resolve().parent.parent / "drivers" / "room.md"
+
+
+def load_driver() -> str:
+    """Read the static room driver. No templating (§6.4)."""
+    return _DRIVER_PATH.read_text(encoding="utf-8")
+
+
+# ─── Prompt construction ────────────────────────────────────────────────────
+
+
+def _format_recent(recent: list[dict]) -> str:
+    lines = []
+    for m in recent:
+        frm = m.get("from", "?")
+        kind = m.get("kind", "say")
+        if kind == "pass":
+            lines.append(f"{frm}: (pass)")
+        else:
+            body = m.get("body", "")
+            lines.append(f"{frm}: {body}")
+    return "\n".join(lines)
+
+
+def build_messages(payload: dict, driver_text: str) -> list[dict]:
+    """Assemble the chat-API messages list per §6.2.
+
+    Layout:
+      system: <driver_text>
+      user:   <structured header>
+              <summary? only when present>
+              <recent messages as `from: body` / `from: (pass)`>
+              <closing instruction>
+    """
+    name = payload.get("name", "")
+    thread_id = payload.get("thread_id", "")
+    room = payload.get("room", "")
+    members = payload.get("members", [])
+    summary = payload.get("summary")
+    recent = payload.get("recent", [])
+
+    header_lines = [
+        f"name: {name}",
+        f"thread_id: {thread_id}",
+        f"room: {room}",
+        f"members: {', '.join(members)}",
+    ]
+    parts = ["\n".join(header_lines)]
+
+    if summary:
+        parts.append(f"Earlier in this thread:\n{summary}")
+
+    if recent:
+        parts.append("Recent messages:\n" + _format_recent(recent))
+    else:
+        # Explicit "no recent" signal so the LLM doesn't hallucinate
+        # missing context. Happens on the initiator's first turn when
+        # they opened without a prompt.
+        parts.append("Recent messages: (none)")
+
+    parts.append(
+        "Respond with exactly one of `say: <body>` or `pass:` followed "
+        "by `DONE:` on its own line."
+    )
+    user_content = "\n\n".join(parts)
+    return [
+        {"role": "system", "content": driver_text},
+        {"role": "user", "content": user_content},
+    ]
+
+
+# ─── Response parsing ───────────────────────────────────────────────────────
+
+
+# First line that starts (after optional whitespace) with `say:` or
+# `pass:` (case-insensitive) is the directive. `(?ms)` = multiline,
+# dotall not needed since we match per-line.
+_DIRECTIVE_RE = re.compile(r"^\s*(say|pass)\s*:(.*)$", re.IGNORECASE | re.MULTILINE)
+
+
+def parse_response(content: str, *, thread_id: str) -> tuple[str, dict]:
+    """Parse an LLM response into the frame kind + payload to emit.
+
+    Degradation policy: any malformed output — no directive, empty
+    say body, multiple directives, missing `DONE:` — degrades to
+    ``pass`` rather than emitting a frame the lobby would nack.
+    Emitting a nacked frame wastes the turn and produces noise; a
+    clean pass keeps the rotation moving with the same net outcome.
+    """
+    m = _DIRECTIVE_RE.search(content)
+    if m is None:
+        return "pass", {"thread_id": thread_id}
+
+    directive = m.group(1).lower()
+    tail = m.group(2).strip()   # trailing text on the directive line
+
+    if directive == "pass":
+        return "pass", {"thread_id": thread_id}
+
+    # say: gather the body — everything from the tail of the directive
+    # line through any subsequent lines until DONE: or EOF. If the
+    # LLM wraps the body across lines, keep the wrap (a human reading
+    # scrollback should see what the LLM said, not a truncation).
+    start = m.end()
+    # Skip the newline that terminated the directive line — it's a
+    # delimiter, not a blank line in the body. Blank lines AFTER it
+    # (e.g., inside a code block) are preserved.
+    rest = content[start:]
+    if rest.startswith("\n"):
+        rest = rest[1:]
+    # Stop at DONE: on its own-ish line, or at another directive line.
+    body_lines = [tail] if tail else []
+    for line in rest.splitlines():
+        stripped = line.strip()
+        if stripped.upper().startswith("DONE:"):
+            break
+        if _DIRECTIVE_RE.match(line):
+            break
+        body_lines.append(line)
+    body = "\n".join(body_lines).strip()
+
+    if not body:
+        # Driver violation: `say:` with empty body. Degrade to pass.
+        return "pass", {"thread_id": thread_id}
+
+    return "say", {"thread_id": thread_id, "body": body}
+
+
+# ─── decide_turn — the composed entry point ─────────────────────────────────
+
+
+def decide_turn(
+    payload: dict,
+    *,
+    llm_client,
+    driver_text: Optional[str] = None,
+    model: Optional[str] = None,
+    max_tokens: int = 512,
+) -> tuple[str, dict]:
+    """End-to-end turn decision: build prompt → call LLM → parse.
+
+    ``driver_text`` defaults to the packaged ``drivers/room.md``; tests
+    can inject a short stand-in. ``max_tokens`` is intentionally small
+    because room messages are short — a higher cap makes a
+    misbehaving/chatty model produce multi-paragraph filler, which the
+    driver forbids anyway and which the lobby would slow-path.
+    """
+    from llm import chat
+
+    if driver_text is None:
+        driver_text = load_driver()
+
+    messages = build_messages(payload, driver_text=driver_text)
+    try:
+        content, _pt, _ct = chat(
+            llm_client, messages, max_tokens=max_tokens, model=model,
+        )
+    except Exception as e:
+        _log.warning("room_runner: llm.chat failed (%s) — passing turn", e)
+        return "pass", {"thread_id": payload.get("thread_id", "")}
+
+    return parse_response(content, thread_id=payload.get("thread_id", ""))

--- a/src/clive/lobby_client.py
+++ b/src/clive/lobby_client.py
@@ -1,0 +1,5 @@
+"""Compatibility shim — aliases networking.lobby_client."""
+import importlib as _importlib
+import sys as _sys
+_real = _importlib.import_module("networking.lobby_client")
+_sys.modules[__name__] = _real

--- a/src/clive/lobby_connector.py
+++ b/src/clive/lobby_connector.py
@@ -1,0 +1,5 @@
+"""Compatibility shim — aliases networking.lobby_connector."""
+import importlib as _importlib
+import sys as _sys
+_real = _importlib.import_module("networking.lobby_connector")
+_sys.modules[__name__] = _real

--- a/src/clive/lobby_server.py
+++ b/src/clive/lobby_server.py
@@ -1,0 +1,5 @@
+"""Compatibility shim — aliases networking.lobby_server."""
+import importlib as _importlib
+import sys as _sys
+_real = _importlib.import_module("networking.lobby_server")
+_sys.modules[__name__] = _real

--- a/src/clive/lobby_state.py
+++ b/src/clive/lobby_state.py
@@ -1,0 +1,5 @@
+"""Compatibility shim — aliases networking.lobby_state."""
+import importlib as _importlib
+import sys as _sys
+_real = _importlib.import_module("networking.lobby_state")
+_sys.modules[__name__] = _real

--- a/src/clive/networking/lobby_client.py
+++ b/src/clive/networking/lobby_client.py
@@ -57,7 +57,12 @@ def run(socket_path: Optional[str] = None,
 
     sel = selectors.DefaultSelector()
     stdin_fd = stdin.fileno()
-    sock.setblocking(False)
+    # Deliberately leave the socket in blocking mode so that
+    # `sock.sendall(chunk)` waits out transient send-buffer pressure
+    # instead of raising BlockingIOError. `sock.recv()` is only called
+    # after `select()` reports EVENT_READ so it will never block. The
+    # stdin side must be non-blocking because `os.read()` on a TTY or
+    # pipe blocks in the absence of set_blocking(False).
     os.set_blocking(stdin_fd, False)
 
     sel.register(stdin_fd, selectors.EVENT_READ, data="stdin")

--- a/src/clive/networking/lobby_client.py
+++ b/src/clive/networking/lobby_client.py
@@ -1,0 +1,104 @@
+"""Lobby client wrapper — bridges stdin/stdout to the lobby Unix socket.
+
+Invoked as the SSH remote command::
+
+    ssh lobbyhost clive --role lobby-client
+
+This process:
+
+1. Reads the session nonce from ``CLIVE_FRAME_NONCE`` (forwarded via
+   SSH ``SendEnv``), or generates a no-op empty nonce for dev use.
+2. Connects to the lobby Unix socket (default ``~/.clive/lobby/lobby.sock``).
+3. Writes the handshake line ``NONCE <nonce>\\n``.
+4. Enters a ``selectors``-based bidi pipe: stdin → socket, socket → stdout.
+
+Exits on EOF from either side or on socket close.
+
+The wrapper does not parse frames; it is transparent. Framing,
+encoding, and decoding live in ``protocol.py`` on both sides of the
+pipe (the user's local clive on one end, the lobby server on the
+other).
+"""
+from __future__ import annotations
+
+import os
+import selectors
+import socket
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_SOCKET = Path.home() / ".clive" / "lobby" / "lobby.sock"
+
+
+def run(socket_path: Optional[str] = None,
+        nonce: Optional[str] = None,
+        stdin=None, stdout=None) -> int:
+    """Bridge loop. Returns an exit status suitable for ``SystemExit``."""
+    sp = socket_path or str(DEFAULT_SOCKET)
+    n = nonce if nonce is not None else os.environ.get("CLIVE_FRAME_NONCE", "")
+    stdin = stdin if stdin is not None else sys.stdin.buffer
+    stdout = stdout if stdout is not None else sys.stdout.buffer
+
+    try:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(sp)
+    except OSError as e:
+        print(f"lobby-client: cannot connect to {sp}: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        sock.sendall(f"NONCE {n}\n".encode("ascii"))
+    except OSError as e:
+        print(f"lobby-client: handshake failed: {e}", file=sys.stderr)
+        sock.close()
+        return 1
+
+    sel = selectors.DefaultSelector()
+    stdin_fd = stdin.fileno()
+    sock.setblocking(False)
+    os.set_blocking(stdin_fd, False)
+
+    sel.register(stdin_fd, selectors.EVENT_READ, data="stdin")
+    sel.register(sock, selectors.EVENT_READ, data="sock")
+
+    try:
+        while True:
+            for key, _ in sel.select(timeout=None):
+                if key.data == "stdin":
+                    try:
+                        chunk = os.read(stdin_fd, 4096)
+                    except BlockingIOError:
+                        continue
+                    if not chunk:
+                        # local EOF → tell server we're done and keep
+                        # draining the socket until it closes
+                        try:
+                            sock.shutdown(socket.SHUT_WR)
+                        except OSError:
+                            pass
+                        sel.unregister(stdin_fd)
+                    else:
+                        try:
+                            sock.sendall(chunk)
+                        except OSError:
+                            return 0
+                elif key.data == "sock":
+                    try:
+                        chunk = sock.recv(4096)
+                    except BlockingIOError:
+                        continue
+                    if not chunk:
+                        return 0
+                    try:
+                        stdout.write(chunk)
+                        stdout.flush()
+                    except OSError:
+                        return 0
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass
+        sel.close()

--- a/src/clive/networking/lobby_connector.py
+++ b/src/clive/networking/lobby_connector.py
@@ -1,0 +1,99 @@
+"""Localhost lobby connector.
+
+Given a locally-registered lobby name (as appears under
+``~/.clive/instances/``), open a Unix-socket connection to its
+broker, complete the ``NONCE`` handshake, and hand the caller a
+ready-to-use blocking socket plus the session nonce.
+
+    sock, nonce = connect_local("lobby")
+    # `sock` ready for framed IO
+    # `nonce` used to stamp outbound frames and decode inbound ones
+
+For remote (SSH-reachable) lobbies the transport is a subprocess
+pipe running ``clive --role lobby-client`` on the remote, with the
+nonce forwarded via ``CLIVE_FRAME_NONCE`` env var. That path comes
+in a later commit; this module handles the co-located case first so
+the CLI wire-up (``--join room@lobby``) has a name-resolution target
+on day one.
+
+Design reference: docs/plans/2026-04-14-clive-rooms-design.md §6.3
+(membership declaration) and §8.2 (clients reach the lobby).
+"""
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+from typing import Optional
+
+from protocol import generate_nonce
+import registry
+
+
+class ConnectError(RuntimeError):
+    """Raised when a lobby cannot be reached. Kept distinct from the
+    generic OSError raised by the socket layer so callers can
+    present a helpful user-facing message without swallowing real
+    IO errors elsewhere."""
+
+
+def connect_local(
+    lobby_name: str,
+    *,
+    nonce: Optional[str] = None,
+    registry_dir: Optional[Path] = None,
+) -> tuple[socket.socket, str]:
+    """Connect to a locally-registered lobby.
+
+    Returns ``(sock, nonce)`` where ``sock`` is a connected blocking
+    ``AF_UNIX`` socket that has already completed the ``NONCE``
+    handshake line, and ``nonce`` is the string the caller should
+    use to stamp outbound frames and decode inbound ones.
+
+    Keeps the socket blocking so a caller using it with ``sendall``
+    does not have to handle partial-write bookkeeping. Callers that
+    plug the socket into a selectors loop should flip to
+    non-blocking themselves (and handle the write path accordingly).
+
+    If ``nonce`` is not supplied a fresh one is minted via
+    ``protocol.generate_nonce``. For the SSH transport (later
+    commit) the outer process supplies the nonce so the remote
+    lobby-client bridge can read it from ``CLIVE_FRAME_NONCE``.
+    """
+    entry = registry.get_instance(lobby_name, registry_dir=registry_dir)
+    if entry is None:
+        raise ConnectError(
+            f"lobby {lobby_name!r} is not registered as a live local "
+            f"instance — is the broker running?"
+        )
+    if entry.get("role") != "broker":
+        raise ConnectError(
+            f"instance {lobby_name!r} is not a broker "
+            f"(role={entry.get('role')!r})"
+        )
+    sock_path = entry.get("socket_path")
+    if not sock_path:
+        raise ConnectError(
+            f"broker {lobby_name!r} has no socket_path in its registry "
+            f"entry — schema drift or partial startup"
+        )
+
+    n = nonce if nonce is not None else generate_nonce()
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.connect(sock_path)
+    except OSError as e:
+        sock.close()
+        raise ConnectError(
+            f"cannot connect to lobby {lobby_name!r} at {sock_path}: {e}"
+        ) from e
+
+    try:
+        sock.sendall(f"NONCE {n}\n".encode("ascii"))
+    except OSError as e:
+        sock.close()
+        raise ConnectError(
+            f"handshake with lobby {lobby_name!r} failed: {e}"
+        ) from e
+
+    return sock, n

--- a/src/clive/networking/lobby_connector.py
+++ b/src/clive/networking/lobby_connector.py
@@ -25,8 +25,15 @@ import socket
 from pathlib import Path
 from typing import Optional
 
+import re
+
 from protocol import generate_nonce
 import registry
+
+
+# Matches the strict nonce alphabet defined in protocol.py's
+# `_NONCE_ALPHABET`. Empty string is permitted (unauthenticated frames).
+_NONCE_ALPHABET = re.compile(r"\A[A-Za-z0-9_-]*\Z")
 
 
 class ConnectError(RuntimeError):
@@ -78,6 +85,15 @@ def connect_local(
         )
 
     n = nonce if nonce is not None else generate_nonce()
+    if not _NONCE_ALPHABET.match(n):
+        # Fail loudly here rather than after the lobby closes the
+        # socket during its own handshake validation — the resulting
+        # "broken pipe on next send" is an opaque way to learn about
+        # a malformed nonce.
+        raise ConnectError(
+            f"nonce contains disallowed characters: {n!r} "
+            f"(alphabet is [A-Za-z0-9_-])"
+        )
 
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     try:

--- a/src/clive/networking/lobby_server.py
+++ b/src/clive/networking/lobby_server.py
@@ -115,23 +115,50 @@ class LobbyServer:
 
     def start(self) -> None:
         """Bind the socket, register in the instance registry, and
-        prepare the selector. Does NOT enter the event loop."""
+        prepare the selector. Does NOT enter the event loop.
+
+        Raises RuntimeError if another live broker is already
+        registered under the same instance name. This prevents the
+        otherwise-silent data loss where the second start() would
+        unlink the first's socket file and overwrite its registry
+        entry, killing connectivity for all already-connected clients.
+        """
         if self._started:
             raise RuntimeError("LobbyServer.start() called twice")
+
+        # Collision check — before we touch the filesystem.
+        if self.instance_name:
+            existing = registry.get_instance(
+                self.instance_name, registry_dir=self.registry_dir,
+            )
+            if existing is not None:
+                raise RuntimeError(
+                    f"lobby instance {self.instance_name!r} is already "
+                    f"running (PID {existing.get('pid', '?')})"
+                )
+
         self._started = True
 
-        # Remove stale socket (prior crash) before bind. This is safe
-        # because the registry check at `_register_instance` rejects
-        # double-start for live PIDs.
+        # Remove stale socket (prior crash). Safe because we just
+        # verified no live PID claims this instance name.
         try:
             os.unlink(self.socket_path)
         except FileNotFoundError:
             pass
 
+        # Create the socket with owner-only permissions from the
+        # moment it exists. Temporarily tighten umask around bind()
+        # because bind() honours the process umask, then restore.
+        # Without this there is a TOCTOU window where the socket is
+        # world-readable between bind and chmod.
         listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         listener.setblocking(False)
-        listener.bind(self.socket_path)
-        os.chmod(self.socket_path, 0o600)   # owner-only
+        prev_umask = os.umask(0o077)
+        try:
+            listener.bind(self.socket_path)
+        finally:
+            os.umask(prev_umask)
+        os.chmod(self.socket_path, 0o600)   # defence-in-depth
         listener.listen(16)
         self._listener = listener
         self.sel.register(listener, selectors.EVENT_READ, data=("listener", None))
@@ -167,11 +194,24 @@ class LobbyServer:
             self._teardown()
 
     def shutdown(self) -> None:
-        """Signal the event loop to exit. Safe to call from any thread."""
+        """Signal the event loop to exit. Safe to call from any thread.
+
+        The `_shutdown` event is the load-bearing signal (checked at
+        the top of each loop iteration). The self-pipe write is just
+        to wake an in-flight `select()` promptly; if we race with
+        teardown and the write fails, shutdown still progresses, just
+        up to one `select` timeout slower.
+        """
         self._shutdown.set()
-        if self._wake_w is not None:
+        # Snapshot the fd before writing to minimise the race window
+        # where teardown might close + reassign `_wake_w`. Benign
+        # because teardown only runs after the event loop exits, and
+        # the event loop does not open new fds after that. A stray
+        # write after close raises OSError which we swallow.
+        w = self._wake_w
+        if w is not None:
             try:
-                os.write(self._wake_w, b"x")
+                os.write(w, b"x")
             except OSError:
                 pass
 
@@ -182,6 +222,12 @@ class LobbyServer:
         try:
             sock, _ = self._listener.accept()
         except BlockingIOError:
+            return
+        except OSError as e:
+            # EMFILE / ENFILE (fd exhaustion) or ECONNABORTED: do NOT
+            # propagate — that would tear down the event loop and drop
+            # every connected session over a single transient error.
+            _log.warning("lobby: accept() failed: %s", e)
             return
         sock.setblocking(False)
         fd = sock.fileno()
@@ -376,11 +422,13 @@ class LobbyServer:
                 os.close(self._wake_r)
             except OSError:
                 pass
+            self._wake_r = None
         if self._wake_w is not None:
             try:
                 os.close(self._wake_w)
             except OSError:
                 pass
+            self._wake_w = None
         try:
             os.unlink(self.socket_path)
         except FileNotFoundError:

--- a/src/clive/networking/lobby_server.py
+++ b/src/clive/networking/lobby_server.py
@@ -1,0 +1,389 @@
+"""Lobby IO layer — selectors-based Unix-socket server.
+
+This is the thin transport wrapper around ``lobby_state.handle``. The
+state machine does not know about sockets, nonces, or byte buffers;
+this module is what turns raw stream bytes into ``Frame`` dispatches
+and routes ``Send`` responses back to the right connection, stamped
+with that connection's own nonce.
+
+Architecture (see design §5.1):
+
+    SSH client ───► clive --role lobby-client (wrapper)
+                              │
+                         Unix socket
+                              │
+                              ▼
+                     LobbyServer.run_forever
+                     (single-threaded selectors loop)
+                              │
+                              ▼
+                     lobby_state.handle()
+
+Per-connection handshake (one line, before framed IO begins):
+
+    NONCE <urlsafe-b64-nonce>\\n
+
+The server captures the nonce and uses it to (a) validate inbound
+frames and (b) stamp outbound frames. Per §7.2, each SSH session has
+its own nonce so a compromised member cannot forge fanout frames for
+another member — the other member's incoming stream is decoded with
+*its own* nonce, which the attacker does not hold.
+
+This module is deliberately minimal for Phase 2 of
+docs/plans/2026-04-14-clive-rooms-design.md:
+session_hello/ack + accept + nack of unknown kinds + clean drop.
+Rooms/threads/fanout all flow through `handle()` and are exercised
+in later phases without needing changes here.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import selectors
+import socket
+import threading
+from pathlib import Path
+from typing import Optional
+
+from protocol import decode_all, encode
+from lobby_state import LobbyState, handle
+import registry
+
+_log = logging.getLogger(__name__)
+
+_HANDSHAKE_PREFIX = b"NONCE "
+_HANDSHAKE_MAX_LEN = 256  # refuse pathologically long handshake lines
+
+
+class _Conn:
+    """One accepted Unix-socket connection.
+
+    The connection goes through exactly two states:
+
+    1. ``handshake``: we are reading the ``NONCE <value>\\n`` line.
+       Any bytes that do not look like the handshake line close the
+       connection.
+    2. ``framed``: we read ``\\n``-delimited frame text lines and feed
+       each line to ``decode_all(line, nonce=self.nonce)``. Mismatched
+       frames are silently dropped by ``decode_all``.
+    """
+
+    __slots__ = ("fd", "sock", "in_buf", "out_buf", "nonce",
+                 "handshake_done", "registered", "closed")
+
+    def __init__(self, fd: int, sock: socket.socket):
+        self.fd = fd
+        self.sock = sock
+        self.in_buf = b""
+        self.out_buf = b""
+        self.nonce = ""
+        self.handshake_done = False
+        self.registered = False
+        self.closed = False
+
+
+class LobbyServer:
+    """Selectors-based Unix socket lobby.
+
+    Public API:
+        srv = LobbyServer(socket_path, registry_dir, instance_name)
+        srv.start()               # create socket & registry entry
+        srv.run_forever()         # blocks; call in a thread or main
+        srv.shutdown()            # thread-safe; wakes the loop
+
+    The server is single-threaded (one ``DefaultSelector``) per §5.1.
+    Shutdown uses a self-pipe to wake the ``select()`` call from any
+    thread without racing against epoll state.
+    """
+
+    def __init__(self, socket_path: str,
+                 registry_dir: Optional[Path] = None,
+                 instance_name: Optional[str] = None):
+        self.socket_path = socket_path
+        self.registry_dir = registry_dir
+        self.instance_name = instance_name
+        self.state = LobbyState()
+        self.sel = selectors.DefaultSelector()
+        self.conns: dict[int, _Conn] = {}
+        self._listener: Optional[socket.socket] = None
+        self._wake_r: Optional[int] = None
+        self._wake_w: Optional[int] = None
+        self._shutdown = threading.Event()
+        self._started = False
+
+    # ─── Lifecycle ──────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Bind the socket, register in the instance registry, and
+        prepare the selector. Does NOT enter the event loop."""
+        if self._started:
+            raise RuntimeError("LobbyServer.start() called twice")
+        self._started = True
+
+        # Remove stale socket (prior crash) before bind. This is safe
+        # because the registry check at `_register_instance` rejects
+        # double-start for live PIDs.
+        try:
+            os.unlink(self.socket_path)
+        except FileNotFoundError:
+            pass
+
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.setblocking(False)
+        listener.bind(self.socket_path)
+        os.chmod(self.socket_path, 0o600)   # owner-only
+        listener.listen(16)
+        self._listener = listener
+        self.sel.register(listener, selectors.EVENT_READ, data=("listener", None))
+
+        # Self-pipe for wakeup. A write to _wake_w makes select() return.
+        r, w = os.pipe()
+        os.set_blocking(r, False)
+        self._wake_r, self._wake_w = r, w
+        self.sel.register(r, selectors.EVENT_READ, data=("wake", None))
+
+        self._register_instance()
+
+    def run_forever(self) -> None:
+        """Run the event loop until ``shutdown()`` is called."""
+        try:
+            while not self._shutdown.is_set():
+                events = self.sel.select(timeout=1.0)
+                for key, mask in events:
+                    tag, _ = key.data
+                    if tag == "listener":
+                        self._accept()
+                    elif tag == "wake":
+                        os.read(self._wake_r, 4096)   # drain
+                    elif tag == "conn":
+                        conn = self.conns.get(key.fd)
+                        if conn is None:
+                            continue
+                        if mask & selectors.EVENT_READ:
+                            self._on_readable(conn)
+                        if (not conn.closed) and (mask & selectors.EVENT_WRITE):
+                            self._on_writable(conn)
+        finally:
+            self._teardown()
+
+    def shutdown(self) -> None:
+        """Signal the event loop to exit. Safe to call from any thread."""
+        self._shutdown.set()
+        if self._wake_w is not None:
+            try:
+                os.write(self._wake_w, b"x")
+            except OSError:
+                pass
+
+    # ─── Accept / close ─────────────────────────────────────────────
+
+    def _accept(self) -> None:
+        assert self._listener is not None
+        try:
+            sock, _ = self._listener.accept()
+        except BlockingIOError:
+            return
+        sock.setblocking(False)
+        fd = sock.fileno()
+        conn = _Conn(fd=fd, sock=sock)
+        self.conns[fd] = conn
+        self.sel.register(sock, selectors.EVENT_READ, data=("conn", conn))
+        _log.debug("lobby: accepted connection fd=%d", fd)
+
+    def _close(self, conn: _Conn) -> None:
+        if conn.closed:
+            return
+        conn.closed = True
+        if conn.registered:
+            self.state.drop_session(conn.fd)
+        try:
+            self.sel.unregister(conn.sock)
+        except (KeyError, ValueError):
+            pass
+        try:
+            conn.sock.close()
+        except OSError:
+            pass
+        self.conns.pop(conn.fd, None)
+        _log.debug("lobby: closed connection fd=%d name=%r", conn.fd, conn.nonce)
+
+    # ─── Read path ──────────────────────────────────────────────────
+
+    def _on_readable(self, conn: _Conn) -> None:
+        try:
+            chunk = conn.sock.recv(4096)
+        except (BlockingIOError, InterruptedError):
+            return
+        except OSError:
+            self._close(conn)
+            return
+        if not chunk:
+            self._close(conn)
+            return
+        conn.in_buf += chunk
+        if not conn.handshake_done:
+            if not self._try_handshake(conn):
+                return
+        # After handshake (or freshly completed handshake), drain any
+        # complete frame lines.
+        self._drain_frames(conn)
+
+    def _try_handshake(self, conn: _Conn) -> bool:
+        """Try to consume the ``NONCE <value>\\n`` handshake line from
+        ``conn.in_buf``. Returns True if handshake completed (caller
+        should then drain framed bytes), False if still waiting or if
+        the connection was closed on malformed input.
+        """
+        nl = conn.in_buf.find(b"\n")
+        if nl < 0:
+            if len(conn.in_buf) > _HANDSHAKE_MAX_LEN:
+                _log.debug("lobby: handshake line too long on fd=%d", conn.fd)
+                self._close(conn)
+            return False
+        line, conn.in_buf = conn.in_buf[:nl], conn.in_buf[nl + 1:]
+        if not line.startswith(_HANDSHAKE_PREFIX):
+            _log.debug("lobby: missing NONCE handshake on fd=%d", conn.fd)
+            self._close(conn)
+            return False
+        nonce = line[len(_HANDSHAKE_PREFIX):].decode("ascii", errors="replace").strip()
+        # Empty nonce is permitted (matches protocol.py convention for
+        # dev/test paths). Validate alphabet to be safe.
+        if not all(c.isalnum() or c in "_-" for c in nonce):
+            _log.debug("lobby: invalid nonce charset on fd=%d", conn.fd)
+            self._close(conn)
+            return False
+        conn.nonce = nonce
+        conn.handshake_done = True
+        self.state.register_session(conn.fd)
+        conn.registered = True
+        return True
+
+    def _drain_frames(self, conn: _Conn) -> None:
+        """Split ``conn.in_buf`` on newlines and dispatch each complete
+        line as a frame. Non-frame content on a line is ignored by
+        ``decode_all``."""
+        while True:
+            nl = conn.in_buf.find(b"\n")
+            if nl < 0:
+                break
+            line, conn.in_buf = conn.in_buf[:nl], conn.in_buf[nl + 1:]
+            if not line:
+                continue
+            text = line.decode("utf-8", errors="replace")
+            frames = decode_all(text, nonce=conn.nonce)
+            for frame in frames:
+                self._dispatch(conn, frame)
+                if conn.closed:
+                    return
+
+    def _dispatch(self, conn: _Conn, frame) -> None:
+        import time as _time
+        sends = handle(self.state, conn.fd, frame, now=_time.time())
+        for send in sends:
+            self._enqueue(send)
+
+    # ─── Write path ─────────────────────────────────────────────────
+
+    def _enqueue(self, send) -> None:
+        target = self.conns.get(send.session_id)
+        if target is None or target.closed:
+            return
+        try:
+            frame = encode(send.kind, send.payload, nonce=target.nonce)
+        except (ValueError, TypeError) as e:
+            _log.error("lobby: failed to encode %s for fd=%d: %s",
+                       send.kind, send.session_id, e)
+            return
+        target.out_buf += (frame + "\n").encode("utf-8")
+        self._arm_write(target)
+
+    def _arm_write(self, conn: _Conn) -> None:
+        if conn.closed or not conn.out_buf:
+            return
+        try:
+            self.sel.modify(conn.sock,
+                            selectors.EVENT_READ | selectors.EVENT_WRITE,
+                            data=("conn", conn))
+        except (KeyError, ValueError):
+            pass
+
+    def _disarm_write(self, conn: _Conn) -> None:
+        if conn.closed:
+            return
+        try:
+            self.sel.modify(conn.sock, selectors.EVENT_READ,
+                            data=("conn", conn))
+        except (KeyError, ValueError):
+            pass
+
+    def _on_writable(self, conn: _Conn) -> None:
+        if not conn.out_buf:
+            self._disarm_write(conn)
+            return
+        try:
+            n = conn.sock.send(conn.out_buf)
+        except (BlockingIOError, InterruptedError):
+            return
+        except OSError:
+            self._close(conn)
+            return
+        conn.out_buf = conn.out_buf[n:]
+        if not conn.out_buf:
+            self._disarm_write(conn)
+
+    # ─── Registry & teardown ────────────────────────────────────────
+
+    def _register_instance(self) -> None:
+        if not self.instance_name:
+            return
+        registry.register(
+            name=self.instance_name,
+            pid=os.getpid(),
+            tmux_session="",
+            tmux_socket="",
+            toolset="",
+            task="",
+            conversational=True,
+            session_dir="",
+            role="broker",
+            socket_path=self.socket_path,
+            registry_dir=self.registry_dir,
+        )
+
+    def _deregister_instance(self) -> None:
+        if not self.instance_name:
+            return
+        registry.deregister(self.instance_name, registry_dir=self.registry_dir)
+
+    def _teardown(self) -> None:
+        for conn in list(self.conns.values()):
+            self._close(conn)
+        if self._listener is not None:
+            try:
+                self.sel.unregister(self._listener)
+            except (KeyError, ValueError):
+                pass
+            try:
+                self._listener.close()
+            except OSError:
+                pass
+        if self._wake_r is not None:
+            try:
+                self.sel.unregister(self._wake_r)
+            except (KeyError, ValueError):
+                pass
+            try:
+                os.close(self._wake_r)
+            except OSError:
+                pass
+        if self._wake_w is not None:
+            try:
+                os.close(self._wake_w)
+            except OSError:
+                pass
+        try:
+            os.unlink(self.socket_path)
+        except FileNotFoundError:
+            pass
+        self._deregister_instance()
+        self.sel.close()

--- a/src/clive/networking/lobby_state.py
+++ b/src/clive/networking/lobby_state.py
@@ -1,0 +1,510 @@
+"""Lobby state machine — pure, deterministic, IO-free.
+
+The lobby is the broker for clive rooms. Its core is a pure function:
+
+    handle(state, session_id, frame, now) -> list[Send]
+
+Given a current ``LobbyState``, an inbound ``Frame`` arriving from a
+session, and an absolute timestamp, it mutates the state in place and
+returns the outbound frames the IO layer should emit. No disk, no
+network, no clocks — all injected. This is the property that makes the
+trust-critical piece unit-testable exhaustively.
+
+See ``docs/plans/2026-04-14-clive-rooms-design.md`` §3 (turn
+discipline) and §4 (protocol) for the semantics this encodes.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from protocol import Frame
+
+
+# ─── Data model ──────────────────────────────────────────────────────────────
+
+@dataclass
+class Session:
+    """An SSH session connected to the lobby. `id` is an opaque handle
+    the IO layer hands us (typically a file descriptor or index). We
+    track it so outbound frames can be routed back to the right pipe.
+
+    Before a session sends ``session_hello`` the fields ``name`` and
+    ``client_kind`` are empty strings, meaning "unnamed" — the session
+    is accepted but cannot take any action other than ``session_hello``.
+    """
+    id: int
+    name: str = ""
+    client_kind: str = ""   # "clive" | "human" | ""
+    joined_rooms: set[str] = field(default_factory=set)
+
+
+@dataclass
+class Message:
+    """An entry in a thread's append-only log. ``body`` is None for a
+    pass. ``ts`` is the absolute Unix timestamp the lobby accepted the
+    frame."""
+    sender: str
+    kind: str        # "say" | "pass"
+    body: Optional[str]
+    ts: float
+
+
+@dataclass
+class Thread:
+    thread_id: str
+    room: str
+    initiator: str
+    members: list[str]        # ordered; position 0 is the initiator
+    private: bool
+    state: str = "open"       # "open" | "dormant" | "closed"
+    cursor: int = 0           # index into members of the current speaker
+    messages: list[Message] = field(default_factory=list)
+    consecutive_passes: int = 0  # reset on any `say`; counts all-pass rotation
+
+    @property
+    def current_speaker(self) -> str:
+        if not self.members:
+            return ""
+        return self.members[self.cursor]
+
+
+@dataclass
+class Room:
+    name: str
+    member_names: set[str] = field(default_factory=set)   # currently joined
+    thread_ids: list[str] = field(default_factory=list)   # in creation order
+
+
+@dataclass
+class Send:
+    """A single outbound frame the IO layer should deliver."""
+    session_id: int
+    kind: str
+    payload: dict
+
+
+@dataclass
+class LobbyState:
+    rooms: dict[str, Room] = field(default_factory=dict)
+    threads: dict[str, Thread] = field(default_factory=dict)
+    sessions: dict[int, Session] = field(default_factory=dict)
+    # Reverse lookup: claimed name -> session id. Enforces uniqueness of
+    # live names (§7.1).
+    name_to_session: dict[str, int] = field(default_factory=dict)
+    # Per-room monotonic counter used to synthesize thread_ids.
+    _thread_counter: dict[str, int] = field(default_factory=dict)
+    # Recent-messages window passed in `your_turn.recent` (§4.2).
+    recent_window: int = 50
+
+    def ensure_room(self, name: str) -> Room:
+        """Create a room if missing. In production, rooms are defined in
+        lobby.yaml — this lazily materializes one so the state machine
+        can be tested without a config loader."""
+        if name not in self.rooms:
+            self.rooms[name] = Room(name=name)
+        return self.rooms[name]
+
+    def register_session(self, session_id: int) -> Session:
+        """Called by the IO layer when a new SSH connection is accepted,
+        *before* any frame is received."""
+        if session_id not in self.sessions:
+            self.sessions[session_id] = Session(id=session_id)
+        return self.sessions[session_id]
+
+    def drop_session(self, session_id: int) -> None:
+        """Called by the IO layer when the session's pipe closes. Frees
+        the name back into the pool and removes room memberships. Does
+        NOT touch threads — a member dropping mid-thread is handled by
+        rotation/timeout logic (Phase 6)."""
+        sess = self.sessions.pop(session_id, None)
+        if sess is None:
+            return
+        if sess.name and self.name_to_session.get(sess.name) == session_id:
+            del self.name_to_session[sess.name]
+        for room_name in sess.joined_rooms:
+            room = self.rooms.get(room_name)
+            if room is not None:
+                room.member_names.discard(sess.name)
+
+
+# ─── Dispatch ────────────────────────────────────────────────────────────────
+
+def handle(state: LobbyState, session_id: int, frame: Frame,
+           now: float = 0.0) -> list[Send]:
+    """Dispatch a single inbound frame. Returns the outbound frames to
+    emit. State is mutated in place.
+
+    Unknown or malformed frames produce a ``nack`` and no state change.
+    """
+    sess = state.sessions.get(session_id)
+    if sess is None:
+        # IO layer didn't register; this shouldn't happen in production
+        # but we refuse rather than crash.
+        return []
+
+    kind = frame.kind
+    p = frame.payload
+
+    # session_hello is the only frame a nameless session may send.
+    if kind == "session_hello":
+        return _handle_session_hello(state, sess, p)
+    if not sess.name:
+        return [_nack(session_id, "session_hello_required", kind)]
+
+    if kind == "join_room":
+        return _handle_join_room(state, sess, p)
+    if kind == "open_thread":
+        return _handle_open_thread(state, sess, p, now)
+    if kind == "say":
+        return _handle_say(state, sess, p, now)
+    if kind == "pass":
+        return _handle_pass(state, sess, p, now)
+    if kind == "list_threads":
+        return _handle_list_threads(state, sess, p)
+    if kind == "join_thread":
+        return _handle_join_thread(state, sess, p, now)
+    if kind == "leave_thread":
+        return _handle_leave_thread(state, sess, p)
+    if kind == "close_thread":
+        return _handle_close_thread(state, sess, p)
+    # Any other kind is silently accepted (alive) or rejected (unknown).
+    if kind == "alive":
+        return []
+    return [_nack(session_id, "unknown_kind", kind)]
+
+
+# ─── Handlers ────────────────────────────────────────────────────────────────
+
+def _handle_session_hello(state: LobbyState, sess: Session, p: dict) -> list[Send]:
+    name = p.get("name")
+    client_kind = p.get("client_kind")
+    if not isinstance(name, str) or not name:
+        return [_ack_reject(sess.id, "", "invalid_name")]
+    if client_kind not in ("clive", "human"):
+        return [_ack_reject(sess.id, name, "invalid_client_kind")]
+    # Name uniqueness
+    existing = state.name_to_session.get(name)
+    if existing is not None and existing != sess.id:
+        return [_ack_reject(sess.id, name, "name_in_use")]
+    # Re-hello on the same session: allow idempotently.
+    sess.name = name
+    sess.client_kind = client_kind
+    state.name_to_session[name] = sess.id
+    return [Send(sess.id, "session_ack", {"name": name, "accepted": True})]
+
+
+def _handle_join_room(state: LobbyState, sess: Session, p: dict) -> list[Send]:
+    room_name = p.get("room")
+    if not isinstance(room_name, str) or not room_name:
+        return [_nack(sess.id, "invalid_room", "join_room")]
+    room = state.ensure_room(room_name)
+    room.member_names.add(sess.name)
+    sess.joined_rooms.add(room_name)
+    return []  # join is silent on success; list_threads/your_turn follow naturally
+
+
+def _handle_open_thread(state: LobbyState, sess: Session, p: dict,
+                        now: float) -> list[Send]:
+    room_name = p.get("room")
+    members = p.get("members")
+    private = bool(p.get("private", False))
+    prompt = p.get("prompt", "")
+
+    if not isinstance(room_name, str) or room_name not in state.rooms:
+        return [_nack(sess.id, "invalid_room", "open_thread")]
+    if sess.name not in state.rooms[room_name].member_names:
+        return [_nack(sess.id, "not_in_room", "open_thread")]
+    if not isinstance(members, list) or not members:
+        return [_nack(sess.id, "invalid_members", "open_thread")]
+    if not all(isinstance(m, str) and m for m in members):
+        return [_nack(sess.id, "invalid_members", "open_thread")]
+    if members[0] != sess.name:
+        return [_nack(sess.id, "initiator_must_be_first", "open_thread")]
+    # Every listed member must be a current room member (§4.4
+    # validation). An offline/absent name would immediately stall the
+    # rotation, so reject rather than silently accept.
+    room = state.rooms[room_name]
+    missing = [m for m in members if m not in room.member_names]
+    if missing:
+        return [_nack(sess.id, f"members_not_in_room:{','.join(missing)}",
+                      "open_thread")]
+    if len(set(members)) != len(members):
+        return [_nack(sess.id, "duplicate_members", "open_thread")]
+    if not isinstance(prompt, str):
+        return [_nack(sess.id, "invalid_prompt", "open_thread")]
+
+    # Assign a lobby-owned thread_id (§C4 fix).
+    state._thread_counter[room_name] = state._thread_counter.get(room_name, 0) + 1
+    thread_id = f"{room_name}-t{state._thread_counter[room_name]:03d}"
+    thread = Thread(
+        thread_id=thread_id,
+        room=room_name,
+        initiator=sess.name,
+        members=list(members),
+        private=private,
+    )
+    # The opening prompt is appended as the initiator's first `say`.
+    # Cursor stays at 0 (initiator) until they emit the prompt implicitly.
+    # Simpler model: the prompt IS the first message; cursor advances
+    # to members[1] and they receive `your_turn`.
+    if prompt:
+        thread.messages.append(Message(sender=sess.name, kind="say",
+                                       body=prompt, ts=now))
+        thread.consecutive_passes = 0
+        thread.cursor = 1 % len(thread.members)
+    state.threads[thread_id] = thread
+    room.thread_ids.append(thread_id)
+
+    out: list[Send] = [
+        Send(sess.id, "thread_opened", {"thread_id": thread_id}),
+    ]
+    # Fanout the opening prompt to everyone else (if any prompt).
+    if prompt:
+        out.extend(_fanout_message(state, thread, sess.name, "say",
+                                   body=prompt, include_initiator=False))
+        # Notify the new current speaker (members[1]) that it's their turn.
+        out.extend(_emit_your_turn(state, thread))
+    else:
+        # No prompt — initiator still holds cursor. Send your_turn so
+        # they can issue a message as the first move.
+        out.extend(_emit_your_turn(state, thread))
+    return out
+
+
+def _handle_say(state: LobbyState, sess: Session, p: dict,
+                now: float) -> list[Send]:
+    thread, err = _resolve_thread(state, sess, p, "say")
+    if err:
+        return [err]
+    if sess.client_kind == "human":
+        return _handle_human_say(state, sess, thread, p, now)
+    if thread.current_speaker != sess.name:
+        return [_nack(sess.id, "not_your_turn", "say")]
+    body = p.get("body")
+    if not isinstance(body, str) or not body:
+        return [_nack(sess.id, "invalid_body", "say")]
+    thread.messages.append(Message(sender=sess.name, kind="say",
+                                   body=body, ts=now))
+    thread.consecutive_passes = 0
+    out = _fanout_message(state, thread, sess.name, "say", body=body,
+                          include_initiator=False)
+    _advance_cursor(thread)
+    out.extend(_emit_your_turn(state, thread))
+    return out
+
+
+def _handle_pass(state: LobbyState, sess: Session, p: dict,
+                 now: float) -> list[Send]:
+    thread, err = _resolve_thread(state, sess, p, "pass")
+    if err:
+        return [err]
+    if sess.client_kind == "human":
+        # Humans never pass; they only initiate or inject (§3.3).
+        return [_nack(sess.id, "humans_do_not_pass", "pass")]
+    if thread.current_speaker != sess.name:
+        return [_nack(sess.id, "not_your_turn", "pass")]
+    thread.messages.append(Message(sender=sess.name, kind="pass",
+                                   body=None, ts=now))
+    thread.consecutive_passes += 1
+    out = _fanout_message(state, thread, sess.name, "pass", body=None,
+                          include_initiator=False)
+    _advance_cursor(thread)
+    # Quiescence: a full rotation of passes with cursor back at the
+    # initiator means every online-in-membership clive has passed once.
+    # Phase 2 treats every member as online; Phase 6 adds offline
+    # skipping.
+    if (thread.consecutive_passes >= len(thread.members)
+            and thread.cursor == 0):
+        thread.state = "dormant"
+        return out  # no your_turn emission — thread is idle
+    out.extend(_emit_your_turn(state, thread))
+    return out
+
+
+def _handle_human_say(state: LobbyState, sess: Session, thread: Thread,
+                      p: dict, now: float) -> list[Send]:
+    """Humans bypass current_speaker and reset the rotation cursor so
+    clives respond to the fresh prompt (§3.3)."""
+    body = p.get("body")
+    if not isinstance(body, str) or not body:
+        return [_nack(sess.id, "invalid_body", "say")]
+    thread.messages.append(Message(sender=sess.name, kind="say",
+                                   body=body, ts=now))
+    thread.consecutive_passes = 0
+    # If the thread was dormant, a human prompt reopens it.
+    if thread.state == "dormant":
+        thread.state = "open"
+    out = _fanout_message(state, thread, sess.name, "say", body=body,
+                          include_initiator=True)
+    # Reset cursor to the first clive member (human is typically not in
+    # members[]; if they are, advance past them).
+    thread.cursor = 0
+    while (thread.cursor < len(thread.members)
+           and thread.members[thread.cursor] == sess.name):
+        thread.cursor = (thread.cursor + 1) % len(thread.members)
+        if thread.cursor == 0:
+            break  # degenerate: only the human is in members
+    if thread.members:
+        out.extend(_emit_your_turn(state, thread))
+    return out
+
+
+def _handle_list_threads(state: LobbyState, sess: Session, p: dict) -> list[Send]:
+    room_name = p.get("room")
+    if not isinstance(room_name, str) or room_name not in state.rooms:
+        return [_nack(sess.id, "invalid_room", "list_threads")]
+    threads = []
+    for tid in state.rooms[room_name].thread_ids:
+        t = state.threads[tid]
+        # Private threads are completely invisible to non-members (§7.1).
+        if t.private and sess.name not in t.members:
+            continue
+        threads.append({
+            "thread_id": t.thread_id,
+            "initiator": t.initiator,
+            "members": list(t.members),
+            "state": t.state,
+            "message_count": len(t.messages),
+            "private": t.private,
+        })
+    return [Send(sess.id, "threads", {"room": room_name, "threads": threads})]
+
+
+def _handle_join_thread(state: LobbyState, sess: Session, p: dict,
+                        now: float) -> list[Send]:
+    tid = p.get("thread_id")
+    if not isinstance(tid, str) or tid not in state.threads:
+        return [_nack(sess.id, "invalid_thread", "join_thread")]
+    thread = state.threads[tid]
+    if sess.name not in state.rooms[thread.room].member_names:
+        return [_nack(sess.id, "not_in_room", "join_thread")]
+    if thread.state == "closed":
+        return [_nack(sess.id, "thread_closed", "join_thread")]
+    if sess.name in thread.members:
+        return []  # already a member; idempotent
+    if thread.private:
+        # Private threads: late admission is a non-goal in v1 (§1,
+        # non-goal "Late admission into private threads").
+        return [_nack(sess.id, "private_thread", "join_thread")]
+    thread.members.append(sess.name)
+    return []
+
+
+def _handle_leave_thread(state: LobbyState, sess: Session, p: dict) -> list[Send]:
+    tid = p.get("thread_id")
+    if not isinstance(tid, str) or tid not in state.threads:
+        return [_nack(sess.id, "invalid_thread", "leave_thread")]
+    thread = state.threads[tid]
+    if sess.name not in thread.members:
+        return []  # idempotent
+    idx = thread.members.index(sess.name)
+    thread.members.remove(sess.name)
+    # Adjust cursor so it points at the same *next* speaker semantics.
+    if not thread.members:
+        thread.state = "closed"
+        thread.cursor = 0
+        return []
+    if idx < thread.cursor:
+        thread.cursor -= 1
+    thread.cursor %= len(thread.members)
+    # Initiator leaving: ownership transfers to the new position-0
+    # member (§3, rule 6).
+    if sess.name == thread.initiator:
+        thread.initiator = thread.members[0]
+    return []
+
+
+def _handle_close_thread(state: LobbyState, sess: Session, p: dict) -> list[Send]:
+    tid = p.get("thread_id")
+    if not isinstance(tid, str) or tid not in state.threads:
+        return [_nack(sess.id, "invalid_thread", "close_thread")]
+    thread = state.threads[tid]
+    if sess.name != thread.initiator:
+        return [_nack(sess.id, "not_initiator", "close_thread")]
+    thread.state = "closed"
+    return []
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+def _resolve_thread(state: LobbyState, sess: Session, p: dict,
+                    ref_kind: str) -> tuple[Optional[Thread], Optional[Send]]:
+    tid = p.get("thread_id")
+    if not isinstance(tid, str) or tid not in state.threads:
+        return None, _nack(sess.id, "invalid_thread", ref_kind)
+    thread = state.threads[tid]
+    if thread.state == "closed":
+        return None, _nack(sess.id, "thread_closed", ref_kind)
+    # Being a thread member is required to say/pass. Humans are
+    # exempt from the "in members" check when injecting (§3.3) —
+    # they're in the room, not necessarily in the thread.
+    if sess.client_kind != "human" and sess.name not in thread.members:
+        return None, _nack(sess.id, "not_in_thread", ref_kind)
+    return thread, None
+
+
+def _advance_cursor(thread: Thread) -> None:
+    """Rotate cursor to the next member. Phase 2 treats all members as
+    online; Phase 6 will add offline-skipping."""
+    if thread.members:
+        thread.cursor = (thread.cursor + 1) % len(thread.members)
+
+
+def _fanout_message(state: LobbyState, thread: Thread, sender: str,
+                    kind: str, body: Optional[str],
+                    include_initiator: bool) -> list[Send]:
+    """Emit say/pass frames to all other thread members, stamped with
+    ``from: sender``. ``include_initiator`` lets the caller choose
+    whether a self-emitted frame echoes back (used when a human's
+    injection needs to be visible to the initiator-clive)."""
+    payload: dict = {"thread_id": thread.thread_id, "from": sender}
+    kind_out = kind  # "say" or "pass"
+    if kind == "say":
+        payload["body"] = body
+    out: list[Send] = []
+    for recipient_name in thread.members:
+        if recipient_name == sender and not include_initiator:
+            continue
+        session_id = state.name_to_session.get(recipient_name)
+        if session_id is None:
+            continue  # offline member — skip (Phase 6 adds replay on rejoin)
+        out.append(Send(session_id, kind_out, dict(payload)))
+    return out
+
+
+def _emit_your_turn(state: LobbyState, thread: Thread) -> list[Send]:
+    """Send ``your_turn`` to the current speaker, carrying the last-K
+    messages per §4.2. Skipped if the thread is dormant/closed."""
+    if thread.state != "open":
+        return []
+    speaker = thread.current_speaker
+    if not speaker:
+        return []
+    session_id = state.name_to_session.get(speaker)
+    if session_id is None:
+        return []  # offline — Phase 6 will auto-pass via timer
+    recent = []
+    for m in thread.messages[-state.recent_window:]:
+        entry: dict = {"from": m.sender, "kind": m.kind}
+        if m.body is not None:
+            entry["body"] = m.body
+        recent.append(entry)
+    payload = {
+        "thread_id": thread.thread_id,
+        "room": thread.room,
+        "name": speaker,
+        "members": list(thread.members),
+        "message_index": len(thread.messages),
+        "recent": recent,
+    }
+    return [Send(session_id, "your_turn", payload)]
+
+
+def _nack(session_id: int, reason: str, ref_kind: str) -> Send:
+    return Send(session_id, "nack", {"reason": reason, "ref_kind": ref_kind})
+
+
+def _ack_reject(session_id: int, name: str, reason: str) -> Send:
+    return Send(session_id, "session_ack",
+                {"name": name, "accepted": False, "reason": reason})

--- a/src/clive/networking/lobby_state.py
+++ b/src/clive/networking/lobby_state.py
@@ -221,6 +221,13 @@ def _handle_open_thread(state: LobbyState, sess: Session, p: dict,
         return [_nack(sess.id, "invalid_members", "open_thread")]
     if members[0] != sess.name:
         return [_nack(sess.id, "initiator_must_be_first", "open_thread")]
+    # Humans are never in rotation (§3.3). Forbid them in `members`;
+    # since members[0] is the initiator, this also forbids human-
+    # initiated threads in v1 (deferred per design open items).
+    for m in members:
+        m_sid = state.name_to_session.get(m)
+        if m_sid is not None and state.sessions[m_sid].client_kind == "human":
+            return [_nack(sess.id, f"human_in_members:{m}", "open_thread")]
     # Every listed member must be a current room member (§4.4
     # validation). An offline/absent name would immediately stall the
     # rotation, so reject rather than silently accept.
@@ -251,7 +258,6 @@ def _handle_open_thread(state: LobbyState, sess: Session, p: dict,
     if prompt:
         thread.messages.append(Message(sender=sess.name, kind="say",
                                        body=prompt, ts=now))
-        thread.consecutive_passes = 0
         thread.cursor = 1 % len(thread.members)
     state.threads[thread_id] = thread
     room.thread_ids.append(thread_id)
@@ -262,7 +268,7 @@ def _handle_open_thread(state: LobbyState, sess: Session, p: dict,
     # Fanout the opening prompt to everyone else (if any prompt).
     if prompt:
         out.extend(_fanout_message(state, thread, sess.name, "say",
-                                   body=prompt, include_initiator=False))
+                                   body=prompt))
         # Notify the new current speaker (members[1]) that it's their turn.
         out.extend(_emit_your_turn(state, thread))
     else:
@@ -282,13 +288,12 @@ def _handle_say(state: LobbyState, sess: Session, p: dict,
     if thread.current_speaker != sess.name:
         return [_nack(sess.id, "not_your_turn", "say")]
     body = p.get("body")
-    if not isinstance(body, str) or not body:
+    if not isinstance(body, str) or not body.strip():
         return [_nack(sess.id, "invalid_body", "say")]
     thread.messages.append(Message(sender=sess.name, kind="say",
                                    body=body, ts=now))
     thread.consecutive_passes = 0
-    out = _fanout_message(state, thread, sess.name, "say", body=body,
-                          include_initiator=False)
+    out = _fanout_message(state, thread, sess.name, "say", body=body)
     _advance_cursor(thread)
     out.extend(_emit_your_turn(state, thread))
     return out
@@ -307,15 +312,15 @@ def _handle_pass(state: LobbyState, sess: Session, p: dict,
     thread.messages.append(Message(sender=sess.name, kind="pass",
                                    body=None, ts=now))
     thread.consecutive_passes += 1
-    out = _fanout_message(state, thread, sess.name, "pass", body=None,
-                          include_initiator=False)
+    out = _fanout_message(state, thread, sess.name, "pass", body=None)
     _advance_cursor(thread)
-    # Quiescence: a full rotation of passes with cursor back at the
-    # initiator means every online-in-membership clive has passed once.
-    # Phase 2 treats every member as online; Phase 6 adds offline
-    # skipping.
-    if (thread.consecutive_passes >= len(thread.members)
-            and thread.cursor == 0):
+    # Quiescence: len(members) consecutive passes means every rotation
+    # participant has had a turn in the streak and passed. Do NOT gate
+    # on `cursor == 0` — that's only true when the initial speaker was
+    # the initiator, which is not the case for threads opened with a
+    # prompt (cursor starts at members[1]). Phase 2 treats every member
+    # as online; Phase 6 adds offline skipping.
+    if thread.consecutive_passes >= len(thread.members):
         thread.state = "dormant"
         return out  # no your_turn emission — thread is idle
     out.extend(_emit_your_turn(state, thread))
@@ -325,9 +330,15 @@ def _handle_pass(state: LobbyState, sess: Session, p: dict,
 def _handle_human_say(state: LobbyState, sess: Session, thread: Thread,
                       p: dict, now: float) -> list[Send]:
     """Humans bypass current_speaker and reset the rotation cursor so
-    clives respond to the fresh prompt (§3.3)."""
+    clives respond to the fresh prompt (§3.3). Private threads still
+    require explicit membership even for humans — the fanout isolation
+    in §7.1 is symmetric."""
+    # Room-membership check lives in _resolve_thread now; by the time we
+    # get here the human is confirmed in thread.room.
+    if thread.private and sess.name not in thread.members:
+        return [_nack(sess.id, "private_thread", "say")]
     body = p.get("body")
-    if not isinstance(body, str) or not body:
+    if not isinstance(body, str) or not body.strip():
         return [_nack(sess.id, "invalid_body", "say")]
     thread.messages.append(Message(sender=sess.name, kind="say",
                                    body=body, ts=now))
@@ -335,16 +346,10 @@ def _handle_human_say(state: LobbyState, sess: Session, thread: Thread,
     # If the thread was dormant, a human prompt reopens it.
     if thread.state == "dormant":
         thread.state = "open"
-    out = _fanout_message(state, thread, sess.name, "say", body=body,
-                          include_initiator=True)
-    # Reset cursor to the first clive member (human is typically not in
-    # members[]; if they are, advance past them).
+    out = _fanout_message(state, thread, sess.name, "say", body=body)
+    # Humans aren't in members (enforced at open_thread), so the cursor
+    # simply resets to position 0.
     thread.cursor = 0
-    while (thread.cursor < len(thread.members)
-           and thread.members[thread.cursor] == sess.name):
-        thread.cursor = (thread.cursor + 1) % len(thread.members)
-        if thread.cursor == 0:
-            break  # degenerate: only the human is in members
     if thread.members:
         out.extend(_emit_your_turn(state, thread))
     return out
@@ -398,6 +403,7 @@ def _handle_leave_thread(state: LobbyState, sess: Session, p: dict) -> list[Send
     thread = state.threads[tid]
     if sess.name not in thread.members:
         return []  # idempotent
+    was_current_speaker = (thread.current_speaker == sess.name)
     idx = thread.members.index(sess.name)
     thread.members.remove(sess.name)
     # Adjust cursor so it points at the same *next* speaker semantics.
@@ -412,7 +418,13 @@ def _handle_leave_thread(state: LobbyState, sess: Session, p: dict) -> list[Send
     # member (§3, rule 6).
     if sess.name == thread.initiator:
         thread.initiator = thread.members[0]
-    return []
+    # If the leaver WAS the current speaker the rotation cursor now
+    # points at a new member who has not been told it is their turn —
+    # emit `your_turn` so the thread doesn't silently hang (H1 fix).
+    out: list[Send] = []
+    if was_current_speaker and thread.state == "open":
+        out.extend(_emit_your_turn(state, thread))
+    return out
 
 
 def _handle_close_thread(state: LobbyState, sess: Session, p: dict) -> list[Send]:
@@ -436,9 +448,15 @@ def _resolve_thread(state: LobbyState, sess: Session, p: dict,
     thread = state.threads[tid]
     if thread.state == "closed":
         return None, _nack(sess.id, "thread_closed", ref_kind)
-    # Being a thread member is required to say/pass. Humans are
-    # exempt from the "in members" check when injecting (§3.3) —
-    # they're in the room, not necessarily in the thread.
+    # Everyone (clive or human) must be in the thread's room. Thread
+    # membership survives session drops, but room membership is
+    # session-scoped — a reconnecting clive must rejoin before acting.
+    if thread.room not in sess.joined_rooms:
+        return None, _nack(sess.id, "not_in_room", ref_kind)
+    # Clives additionally must be in thread.members. Humans are
+    # exempt here because §3.3 lets them inject into any public
+    # thread they are room-members of; _handle_human_say enforces
+    # the private-thread membership requirement.
     if sess.client_kind != "human" and sess.name not in thread.members:
         return None, _nack(sess.id, "not_in_thread", ref_kind)
     return thread, None
@@ -452,24 +470,35 @@ def _advance_cursor(thread: Thread) -> None:
 
 
 def _fanout_message(state: LobbyState, thread: Thread, sender: str,
-                    kind: str, body: Optional[str],
-                    include_initiator: bool) -> list[Send]:
-    """Emit say/pass frames to all other thread members, stamped with
-    ``from: sender``. ``include_initiator`` lets the caller choose
-    whether a self-emitted frame echoes back (used when a human's
-    injection needs to be visible to the initiator-clive)."""
+                    kind: str, body: Optional[str]) -> list[Send]:
+    """Emit say/pass frames to the thread's fanout set, stamped with
+    ``from: sender``. The sender is always excluded — they just typed
+    the frame, echoing it back is noise.
+
+    Recipient set (§4.3):
+      - Private threads: thread members only.
+      - Public threads: union of thread members and room members. A
+        member who joined the thread and then dropped their SSH session
+        is still on thread.members; they are naturally skipped below
+        when their name has no live session.
+    """
     payload: dict = {"thread_id": thread.thread_id, "from": sender}
-    kind_out = kind  # "say" or "pass"
     if kind == "say":
         payload["body"] = body
+    if thread.private:
+        recipient_names: set[str] = set(thread.members)
+    else:
+        room = state.rooms.get(thread.room)
+        room_members: set[str] = set(room.member_names) if room else set()
+        recipient_names = set(thread.members) | room_members
     out: list[Send] = []
-    for recipient_name in thread.members:
-        if recipient_name == sender and not include_initiator:
+    for recipient_name in recipient_names:
+        if recipient_name == sender:
             continue
         session_id = state.name_to_session.get(recipient_name)
         if session_id is None:
-            continue  # offline member — skip (Phase 6 adds replay on rejoin)
-        out.append(Send(session_id, kind_out, dict(payload)))
+            continue  # offline — Phase 6 adds replay-on-rejoin
+        out.append(Send(session_id, kind, dict(payload)))
     return out
 
 

--- a/src/clive/networking/protocol.py
+++ b/src/clive/networking/protocol.py
@@ -41,15 +41,31 @@ _SUFFIX = ">>>"
 
 # Source of truth for frame kinds. Anything else is rejected at decode time.
 KINDS = frozenset({
+    # Core conversational protocol (clive-to-clive)
     "turn",          # payload: {"state": "thinking|waiting|done|failed"}
     "context",       # payload: arbitrary dict (result, error, etc.)
     "question",      # payload: {"text": "..."}
     "file",          # payload: {"name": "..."}
     "progress",      # payload: {"text": "..."}
-    "llm_request",   # payload: {"id": "...", "messages": [...], "model": "...", "max_tokens": N}
-    "llm_response",  # payload: {"id": "...", "content": "...", "prompt_tokens": N, "completion_tokens": N}
-    "llm_error",     # payload: {"id": "...", "error": "..."}
+    "llm_request",   # payload: {"id", "messages", "model", "max_tokens"}
+    "llm_response",  # payload: {"id", "content", "prompt_tokens", "completion_tokens"}
+    "llm_error",     # payload: {"id", "error"}
     "alive",         # payload: {"ts": <float>}
+    # Rooms / lobby (see docs/plans/2026-04-14-clive-rooms-design.md §4)
+    "session_hello",  # member → lobby: {"client_kind", "name"}
+    "session_ack",    # lobby → member: {"name", "accepted", ["reason"]}
+    "join_room",      # member → lobby: {"room"}
+    "list_threads",   # member → lobby: {"room"}
+    "threads",        # lobby → member: {"room", "threads": [...]}
+    "open_thread",    # member → lobby: {"room", "members", "private", "prompt"}
+    "thread_opened",  # lobby → initiator: {"thread_id"}
+    "close_thread",   # initiator → lobby: {"thread_id", ["summary"]}
+    "join_thread",    # member → lobby: {"thread_id"}
+    "leave_thread",   # member → lobby: {"thread_id"}
+    "your_turn",      # lobby → current speaker: structured thread context
+    "say",            # current speaker or human → lobby (fanned out): {"thread_id", "body", ["from"]}
+    "pass",           # current speaker → lobby (fanned out): {"thread_id", ["from"]}
+    "nack",           # lobby → sender: {"reason", "ref_kind"}
 })
 
 # Strict frame regex. `kind` is lowercase alphanumeric/underscore,

--- a/src/clive/networking/registry.py
+++ b/src/clive/networking/registry.py
@@ -21,7 +21,9 @@ def _pid_alive(pid: int) -> bool:
 
 def register(name: str, pid: int, tmux_session: str, tmux_socket: str,
              toolset: str, task: str, conversational: bool, session_dir: str,
-             registry_dir: Path | None = None) -> Path:
+             registry_dir: Path | None = None,
+             role: str | None = None,
+             socket_path: str | None = None) -> Path:
     d = registry_dir or DEFAULT_REGISTRY_DIR
     d.mkdir(parents=True, exist_ok=True)
     entry = {
@@ -35,6 +37,12 @@ def register(name: str, pid: int, tmux_session: str, tmux_socket: str,
         "session_dir": session_dir,
         "started_at": time.time(),
     }
+    # Optional fields (omitted when unset so consumers that don't know
+    # about them never see a surprising key — see §9.6).
+    if role is not None:
+        entry["role"] = role
+    if socket_path is not None:
+        entry["socket_path"] = socket_path
     p = d / f"{name}.json"
     p.write_text(json.dumps(entry, indent=2))
     return p

--- a/src/clive/networking/remote.py
+++ b/src/clive/networking/remote.py
@@ -28,9 +28,19 @@ from protocol import KINDS, decode_all, latest, _FRAME_RE  # type: ignore[attr-d
 
 _log = logging.getLogger(__name__)
 
-# Kinds that we render into the LLM-facing decoded view. `alive` is
-# omitted because keepalives are supervisor signal, not LLM signal.
-_RENDERED_KINDS = frozenset(KINDS - {"alive"})
+# Kinds suppressed from the LLM-facing decoded view.
+# `alive` is keepalive/supervisor signal.
+# `session_hello` and the member→lobby "intent" frames (join_room, list_threads,
+# open_thread, close_thread, join_thread, leave_thread) are outbound-only from
+# a member's perspective; echoing them into that member's LLM context is noise.
+# Lobby→member responses (session_ack, threads, thread_opened, your_turn, nack)
+# and fanout frames (say, pass) DO render because the LLM needs to see them.
+_SUPPRESSED_KINDS = frozenset({
+    "alive", "session_hello",
+    "join_room", "list_threads", "open_thread",
+    "close_thread", "join_thread", "leave_thread",
+})
+_RENDERED_KINDS = frozenset(KINDS - _SUPPRESSED_KINDS)
 
 
 def parse_turn_state(screen: str, nonce: str = "") -> str | None:
@@ -153,6 +163,40 @@ def _render_frame(kind: str, payload: dict) -> str:
         # without cluttering the LLM's context with raw message bodies.
         rid = payload.get("id", "?")
         return f"⎇ CLIVE» {kind} id={rid}"
+    # ── Rooms / lobby frames ────────────────────────────────────────────
+    if kind == "say":
+        author = payload.get("from", "?")
+        tid = payload.get("thread_id", "?")
+        body = payload.get("body", "")
+        return f"⎇ CLIVE» say from {author} [thread {tid}]: {body}"
+    if kind == "pass":
+        author = payload.get("from", "?")
+        tid = payload.get("thread_id", "?")
+        return f"⎇ CLIVE» pass from {author} [thread {tid}]"
+    if kind == "your_turn":
+        # Deliberately do NOT dump `recent` / `summary` — the room_runner
+        # consumes the structured payload directly. Rendering them here
+        # would give the LLM the same content twice.
+        tid = payload.get("thread_id", "?")
+        idx = payload.get("message_index", "?")
+        return f"⎇ CLIVE» your_turn [thread {tid} msg {idx}]"
+    if kind == "thread_opened":
+        tid = payload.get("thread_id", "?")
+        return f"⎇ CLIVE» thread_opened: {tid}"
+    if kind == "nack":
+        reason = payload.get("reason", "?")
+        ref = payload.get("ref_kind", "?")
+        return f"⎇ CLIVE» nack: {reason} (ref: {ref})"
+    if kind == "session_ack":
+        name = payload.get("name", "?")
+        accepted = payload.get("accepted", False)
+        reason = payload.get("reason")
+        tail = f" reason={reason}" if reason else ""
+        return f"⎇ CLIVE» session_ack name={name} accepted={accepted}{tail}"
+    if kind == "threads":
+        room = payload.get("room", "?")
+        count = len(payload.get("threads", []))
+        return f"⎇ CLIVE» threads [room {room}]: {count} visible"
     # Fallback for any future kind: render kind + compact payload
     return f"⎇ CLIVE» {kind}: {json.dumps(payload, separators=(',', ':'))}"
 

--- a/src/clive/room_participant.py
+++ b/src/clive/room_participant.py
@@ -1,0 +1,5 @@
+"""Compatibility shim — aliases execution.room_participant."""
+import importlib as _importlib
+import sys as _sys
+_real = _importlib.import_module("execution.room_participant")
+_sys.modules[__name__] = _real

--- a/src/clive/room_runner.py
+++ b/src/clive/room_runner.py
@@ -1,0 +1,5 @@
+"""Compatibility shim — aliases execution.room_runner."""
+import importlib as _importlib
+import sys as _sys
+_real = _importlib.import_module("execution.room_runner")
+_sys.modules[__name__] = _real

--- a/src/clive/session/conv_loop.py
+++ b/src/clive/session/conv_loop.py
@@ -1,0 +1,200 @@
+"""Selectors-based conversational event loop (Phase 0).
+
+Replaces the blocking ``sys.stdin.readline()`` loop in
+conversational mode with a multiplex over any number of readable
+sources. Same single-line-at-a-time handler contract as before, plus
+the ability to register additional fds (lobby pane reader in Phase 4,
+etc.) without another refactor.
+
+Shape:
+
+    loop = ConvLoop()
+    loop.on_line(sys.stdin, handle_task_line)   # handle_task_line(str) -> bool
+    loop.run()                                   # blocks until EOF / stop / True
+
+Design notes:
+
+* Line framing is implemented with raw ``os.read`` + a per-source
+  byte buffer, not ``file.readline()``. Python's text buffer can
+  stash bytes past a line terminator such that ``select()`` reports
+  nothing readable while more lines sit in the buffer — a real
+  correctness issue for a select-driven loop. Raw reads on
+  non-blocking fds sidestep it.
+
+* A self-pipe lets ``stop()`` wake ``select()`` from any thread
+  (signal handlers, tests, future admin commands).
+
+* Handler exceptions are logged and swallowed so a bad task does not
+  tear down the keep-alive loop — that preserves the contract of the
+  pre-refactor loop, which emitted failure frames but did not exit.
+
+See ``docs/plans/2026-04-14-clive-rooms-design.md`` §6.1.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import selectors
+from typing import Callable
+
+_log = logging.getLogger(__name__)
+
+
+class _LineSource:
+    """One registered line-oriented source. Owns its own byte
+    buffer; yields complete lines on each readable event."""
+
+    __slots__ = ("fd", "handler", "buf", "closed")
+
+    def __init__(self, fd: int, handler: Callable[[str], bool]):
+        self.fd = fd
+        self.handler = handler
+        self.buf = b""
+        self.closed = False
+
+    def drain(self) -> list[str]:
+        """Read whatever bytes are available and return any complete
+        lines (each including the trailing '\\n'). Sets ``closed`` on
+        EOF. Returns [] if the read would have blocked — defensive
+        against spurious ``select`` readiness."""
+        try:
+            data = os.read(self.fd, 4096)
+        except (BlockingIOError, InterruptedError):
+            return []
+        except OSError:
+            self.closed = True
+            return []
+        if not data:
+            self.closed = True
+            return []
+        self.buf += data
+        lines: list[str] = []
+        while b"\n" in self.buf:
+            nl = self.buf.index(b"\n")
+            line = self.buf[:nl + 1].decode("utf-8", errors="replace")
+            self.buf = self.buf[nl + 1:]
+            lines.append(line)
+        return lines
+
+
+class ConvLoop:
+    """Single-threaded selector loop for conversational mode.
+
+    Public surface:
+
+    ``on_line(stream_or_fd, handler)``
+        Register a line-delimited readable. ``handler(line: str)`` is
+        invoked for each complete line; if it returns ``True`` the
+        loop stops. Exceptions are logged, swallowed, and the loop
+        continues.
+
+    ``run()``
+        Block until ``stop()`` is called OR every registered source
+        has hit EOF. Safe against spurious wake-ups.
+
+    ``stop()``
+        Thread-safe signal to end the loop at the next iteration.
+    """
+
+    def __init__(self):
+        self._sel = selectors.DefaultSelector()
+        self._sources: dict[int, _LineSource] = {}
+        self._stop = False
+        # Self-pipe — a write to `_wake_w` makes an in-flight
+        # `select()` return so `stop()` is prompt.
+        r, w = os.pipe()
+        os.set_blocking(r, False)
+        self._wake_r = r
+        self._wake_w = w
+        self._sel.register(r, selectors.EVENT_READ, data=("wake", None))
+
+    # ─── Registration ───────────────────────────────────────────────
+
+    def on_line(self, stream, handler: Callable[[str], bool]) -> None:
+        """Register a readable source. `stream` may be a file-like
+        object (sys.stdin, an `os.fdopen()` wrapper) or a raw fd.
+        The handler receives each complete line as a str including
+        the trailing newline."""
+        fd = stream.fileno() if hasattr(stream, "fileno") else int(stream)
+        # Non-blocking so os.read returns promptly on spurious readiness.
+        # Note: this mutates the fd's blocking state process-wide; the
+        # caller is expected to own the fd for the loop's lifetime.
+        os.set_blocking(fd, False)
+        src = _LineSource(fd, handler)
+        self._sources[fd] = src
+        self._sel.register(fd, selectors.EVENT_READ, data=("line", src))
+
+    # ─── Lifecycle ──────────────────────────────────────────────────
+
+    def stop(self) -> None:
+        """Request the loop to exit at the next iteration. Thread-safe."""
+        self._stop = True
+        if self._wake_w is not None:
+            try:
+                os.write(self._wake_w, b"x")
+            except OSError:
+                pass
+
+    def run(self) -> None:
+        """Run until ``stop()`` is called or all sources hit EOF."""
+        try:
+            while not self._stop and self._sources:
+                events = self._sel.select(timeout=None)
+                for key, _ in events:
+                    tag, payload = key.data
+                    if tag == "wake":
+                        try:
+                            os.read(self._wake_r, 4096)
+                        except OSError:
+                            pass
+                        continue
+                    src: _LineSource = payload
+                    lines = src.drain()
+                    for line in lines:
+                        try:
+                            if src.handler(line) is True:
+                                self._stop = True
+                                break
+                        except Exception as e:
+                            _log.warning(
+                                "conv_loop: handler raised %s — continuing",
+                                e, exc_info=True,
+                            )
+                    if src.closed:
+                        self._drop(src.fd)
+                    if self._stop:
+                        break
+        finally:
+            self._teardown()
+
+    # ─── Internals ──────────────────────────────────────────────────
+
+    def _drop(self, fd: int) -> None:
+        src = self._sources.pop(fd, None)
+        if src is None:
+            return
+        try:
+            self._sel.unregister(fd)
+        except (KeyError, ValueError):
+            pass
+
+    def _teardown(self) -> None:
+        for fd in list(self._sources):
+            self._drop(fd)
+        if self._wake_r is not None:
+            try:
+                self._sel.unregister(self._wake_r)
+            except (KeyError, ValueError):
+                pass
+            try:
+                os.close(self._wake_r)
+            except OSError:
+                pass
+            self._wake_r = None
+        if self._wake_w is not None:
+            try:
+                os.close(self._wake_w)
+            except OSError:
+                pass
+            self._wake_w = None
+        self._sel.close()

--- a/src/clive/session/conv_loop.py
+++ b/src/clive/session/conv_loop.py
@@ -56,16 +56,26 @@ class _LineSource:
         """Read whatever bytes are available and return any complete
         lines (each including the trailing '\\n'). Sets ``closed`` on
         EOF. Returns [] if the read would have blocked — defensive
-        against spurious ``select`` readiness."""
+        against spurious ``select`` readiness.
+
+        On EOF with a non-empty buffer, the trailing bytes are
+        flushed as one last synthetic line (without a '\\n'). This
+        matches the pre-refactor ``sys.stdin.readline()`` contract,
+        which returned a partial final line when the peer closed
+        mid-line. Losing it would be a silent behaviour regression.
+        """
         try:
             data = os.read(self.fd, 4096)
         except (BlockingIOError, InterruptedError):
             return []
         except OSError:
-            self.closed = True
-            return []
+            data = b""
         if not data:
             self.closed = True
+            if self.buf:
+                tail = self.buf.decode("utf-8", errors="replace")
+                self.buf = b""
+                return [tail]
             return []
         self.buf += data
         lines: list[str] = []
@@ -99,6 +109,12 @@ class ConvLoop:
     def __init__(self):
         self._sel = selectors.DefaultSelector()
         self._sources: dict[int, _LineSource] = {}
+        # Per-registered-fd snapshot of the original blocking flag so
+        # we can restore it on teardown. Callers typically pass
+        # ``sys.stdin``, and flipping it to non-blocking permanently
+        # would surprise downstream code (and leak across pytest test
+        # boundaries when the same interpreter is reused).
+        self._original_blocking: dict[int, bool] = {}
         self._stop = False
         # Self-pipe — a write to `_wake_w` makes an in-flight
         # `select()` return so `stop()` is prompt.
@@ -116,9 +132,14 @@ class ConvLoop:
         The handler receives each complete line as a str including
         the trailing newline."""
         fd = stream.fileno() if hasattr(stream, "fileno") else int(stream)
+        # Snapshot the original blocking state before we flip it so
+        # teardown can restore it — otherwise a test that registers
+        # sys.stdin silently leaks non-blocking into subsequent tests.
+        try:
+            self._original_blocking[fd] = os.get_blocking(fd)
+        except OSError:
+            self._original_blocking[fd] = True
         # Non-blocking so os.read returns promptly on spurious readiness.
-        # Note: this mutates the fd's blocking state process-wide; the
-        # caller is expected to own the fd for the loop's lifetime.
         os.set_blocking(fd, False)
         src = _LineSource(fd, handler)
         self._sources[fd] = src
@@ -177,6 +198,12 @@ class ConvLoop:
             self._sel.unregister(fd)
         except (KeyError, ValueError):
             pass
+        prev = self._original_blocking.pop(fd, None)
+        if prev is not None:
+            try:
+                os.set_blocking(fd, prev)
+            except OSError:
+                pass
 
     def _teardown(self) -> None:
         for fd in list(self._sources):

--- a/tests/test_conv_loop.py
+++ b/tests/test_conv_loop.py
@@ -191,6 +191,60 @@ def test_one_source_eof_leaves_other_active():
     w2.close()
 
 
+def test_partial_final_line_on_eof_is_delivered():
+    """When the peer writes bytes without a trailing newline and then
+    closes, the refactored loop must still deliver those bytes as a
+    final line — matching the behaviour of the pre-refactor
+    ``sys.stdin.readline()``, which returned the partial line and then
+    EOF on the next call. Dropping it silently would be a behaviour
+    regression and the kind of bug that only bites under
+    failure-mode traffic (a peer crashing mid-write)."""
+    r, w = _pipe_pair()
+    seen: list[str] = []
+
+    def handle(line: str) -> bool:
+        seen.append(line)   # do NOT strip — test raw line semantics
+        return False
+
+    loop = ConvLoop()
+    loop.on_line(r, handle)
+
+    t = threading.Thread(target=loop.run, daemon=True)
+    t.start()
+    w.write("complete\n")   # normal line
+    w.flush()
+    w.write("partial")      # no trailing \n
+    w.flush()
+    w.close()               # EOF mid-line
+    t.join(timeout=2.0)
+    assert not t.is_alive()
+    assert seen == ["complete\n", "partial"]
+
+
+def test_original_blocking_flag_is_restored(tmp_path):
+    """ConvLoop puts registered fds into non-blocking mode. After
+    teardown it MUST put them back — otherwise a test registering
+    sys.stdin leaks non-blocking into the next pytest test, and in
+    production any post-loop code that reads the fd behaves
+    unexpectedly. This test uses a pipe so we can probe the flag
+    directly without touching sys.stdin."""
+    r, w = os.pipe()
+    try:
+        assert os.get_blocking(r) is True
+        loop = ConvLoop()
+        loop.on_line(r, lambda line: False)
+        # Simulate a source-exhausted run.
+        os.close(w)
+        loop.run()
+        assert os.get_blocking(r) is True, \
+            "ConvLoop left fd in non-blocking state after teardown"
+    finally:
+        try:
+            os.close(r)
+        except OSError:
+            pass
+
+
 # ─── stop() from another thread ─────────────────────────────────────────────
 
 

--- a/tests/test_conv_loop.py
+++ b/tests/test_conv_loop.py
@@ -1,0 +1,212 @@
+"""Tests for ``session/conv_loop.py`` — the selectors-based
+conversational-mode event loop introduced in Phase 0.
+
+Phase 0 is a pure refactor: the loop must still process task lines
+from stdin one at a time, break on EOF, and break on the sentinel
+words (exit/quit//stop). The new contract on top is that multiple
+readable streams may be registered, and the loop multiplexes between
+them — preparing for Phase 4 to register the lobby pane reader.
+
+See docs/plans/2026-04-14-clive-rooms-design.md §6.1.
+"""
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+import pytest
+
+from conv_loop import ConvLoop
+
+
+def _pipe_pair():
+    r, w = os.pipe()
+    return os.fdopen(r, "r", buffering=1), os.fdopen(w, "w", buffering=1)
+
+
+# ─── Single-source behaviour ────────────────────────────────────────────────
+
+
+def test_processes_lines_in_order():
+    r, w = _pipe_pair()
+    seen: list[str] = []
+
+    def handle(line: str) -> bool:
+        seen.append(line.strip())
+        return False
+
+    loop = ConvLoop()
+    loop.on_line(r, handle)
+
+    t = threading.Thread(target=loop.run, daemon=True)
+    t.start()
+    w.write("first\nsecond\nthird\n")
+    w.flush()
+    w.close()
+    t.join(timeout=2.0)
+    assert not t.is_alive()
+    assert seen == ["first", "second", "third"]
+
+
+def test_eof_closes_source_and_exits_when_last():
+    r, w = _pipe_pair()
+    calls = []
+
+    def handle(line: str) -> bool:
+        calls.append(line)
+        return False
+
+    loop = ConvLoop()
+    loop.on_line(r, handle)
+
+    t = threading.Thread(target=loop.run, daemon=True)
+    t.start()
+    w.close()                     # immediate EOF
+    t.join(timeout=2.0)
+    assert not t.is_alive(), "loop did not exit on EOF of only source"
+    assert calls == []
+
+
+def test_handler_returning_true_breaks_loop():
+    r, w = _pipe_pair()
+    seen = []
+
+    def handle(line: str) -> bool:
+        seen.append(line.strip())
+        return line.strip() == "stop"
+
+    loop = ConvLoop()
+    loop.on_line(r, handle)
+
+    t = threading.Thread(target=loop.run, daemon=True)
+    t.start()
+    w.write("one\n")
+    w.flush()
+    w.write("stop\n")
+    w.flush()
+    # These must not be processed because handler returned True on "stop".
+    w.write("never\n")
+    w.flush()
+    t.join(timeout=2.0)
+    assert not t.is_alive()
+    assert seen == ["one", "stop"]
+    w.close()
+
+
+def test_handler_exception_does_not_kill_loop():
+    """Per the existing conv-mode contract, a failed task run emits
+    failure frames but does NOT terminate the keep-alive loop. The
+    refactored loop must preserve this — handler exceptions are
+    logged/swallowed, not propagated."""
+    r, w = _pipe_pair()
+    seen = []
+
+    def handle(line: str) -> bool:
+        seen.append(line.strip())
+        if line.strip() == "boom":
+            raise RuntimeError("synthetic")
+        return False
+
+    loop = ConvLoop()
+    loop.on_line(r, handle)
+
+    t = threading.Thread(target=loop.run, daemon=True)
+    t.start()
+    w.write("ok1\nboom\nok2\n")
+    w.flush()
+    w.close()
+    t.join(timeout=2.0)
+    assert not t.is_alive()
+    assert seen == ["ok1", "boom", "ok2"]
+
+
+# ─── Multi-source multiplex (prepares for phase 4) ──────────────────────────
+
+
+def test_two_sources_multiplexed():
+    """Registering two line sources must dispatch lines from both to
+    their respective handlers. This is the property phase 4 will
+    depend on when it registers the lobby pane reader alongside
+    stdin."""
+    r1, w1 = _pipe_pair()
+    r2, w2 = _pipe_pair()
+    seen_1: list[str] = []
+    seen_2: list[str] = []
+
+    def h1(line: str) -> bool:
+        seen_1.append(line.strip())
+        return False
+
+    def h2(line: str) -> bool:
+        seen_2.append(line.strip())
+        return False
+
+    loop = ConvLoop()
+    loop.on_line(r1, h1)
+    loop.on_line(r2, h2)
+
+    t = threading.Thread(target=loop.run, daemon=True)
+    t.start()
+
+    w1.write("a1\n"); w1.flush()
+    w2.write("b1\n"); w2.flush()
+    w1.write("a2\n"); w1.flush()
+    w2.write("b2\n"); w2.flush()
+    # Close BOTH so the loop exits when no sources remain.
+    w1.close()
+    w2.close()
+    t.join(timeout=2.0)
+    assert not t.is_alive()
+    assert seen_1 == ["a1", "a2"]
+    assert seen_2 == ["b1", "b2"]
+
+
+def test_one_source_eof_leaves_other_active():
+    """Closing only one source must not bring the loop down — the
+    other remains serviceable."""
+    r1, w1 = _pipe_pair()
+    r2, w2 = _pipe_pair()
+    seen_2: list[str] = []
+
+    loop = ConvLoop()
+    loop.on_line(r1, lambda line: False)
+
+    def h2(line: str) -> bool:
+        seen_2.append(line.strip())
+        return line.strip() == "done"
+
+    loop.on_line(r2, h2)
+
+    t = threading.Thread(target=loop.run, daemon=True)
+    t.start()
+    w1.close()                     # first source closes immediately
+    time.sleep(0.05)
+    assert t.is_alive(), "loop exited despite remaining active source"
+    w2.write("still-here\n"); w2.flush()
+    w2.write("done\n"); w2.flush()
+    t.join(timeout=2.0)
+    assert not t.is_alive()
+    assert seen_2 == ["still-here", "done"]
+    w2.close()
+
+
+# ─── stop() from another thread ─────────────────────────────────────────────
+
+
+def test_stop_from_outside_wakes_loop():
+    """`stop()` must cause `run()` to return even if no source is
+    currently readable. Useful for signal handlers."""
+    r, w = _pipe_pair()
+
+    loop = ConvLoop()
+    loop.on_line(r, lambda line: False)
+
+    t = threading.Thread(target=loop.run, daemon=True)
+    t.start()
+    time.sleep(0.05)
+    assert t.is_alive()
+    loop.stop()
+    t.join(timeout=2.0)
+    assert not t.is_alive(), "stop() did not wake the loop"
+    w.close()

--- a/tests/test_lobby_connector.py
+++ b/tests/test_lobby_connector.py
@@ -1,0 +1,183 @@
+"""Tests for ``networking/lobby_connector.py`` — the localhost
+name-resolution helper that a member clive uses when it sees
+``--join room@lobby``.
+
+The connector reads the local instance registry, finds the broker's
+socket path, opens a Unix socket, and completes the ``NONCE`` line
+handshake. For SSH-reachable lobbies the transport flips to a
+subprocess pipe (``ssh lobbyhost clive --role lobby-client``); that
+comes in a later commit.
+
+Tests use a real ``LobbyServer`` so the handshake is end-to-end
+rather than mocked — the handshake is the contract.
+"""
+from __future__ import annotations
+
+import os
+import socket
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from protocol import decode_all, encode
+from lobby_server import LobbyServer
+from lobby_connector import ConnectError, connect_local
+
+
+# ─── Harness ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_registry(tmp_path):
+    d = tmp_path / "instances"
+    d.mkdir()
+    yield d
+
+
+@pytest.fixture
+def running_lobby(tmp_registry):
+    """A real LobbyServer accepting connections on a short ephemeral
+    socket path. Cleans up the socket, registry entry, and server
+    thread on teardown."""
+    fd, sock = tempfile.mkstemp(prefix="clv-", suffix=".sock")
+    os.close(fd); os.unlink(sock)
+    srv = LobbyServer(
+        socket_path=sock,
+        registry_dir=tmp_registry,
+        instance_name="testlobby",
+    )
+    srv.start()
+    t = threading.Thread(target=srv.run_forever, daemon=True)
+    t.start()
+    try:
+        yield srv, sock
+    finally:
+        srv.shutdown()
+        t.join(timeout=2.0)
+        try:
+            os.unlink(sock)
+        except FileNotFoundError:
+            pass
+
+
+# ─── Happy path ─────────────────────────────────────────────────────────────
+
+
+def test_connect_local_completes_handshake(running_lobby, tmp_registry):
+    """`connect_local` resolves the name through the local registry
+    and returns a socket that has already completed the NONCE
+    handshake, so a follow-up `session_hello` succeeds."""
+    _srv, _sock_path = running_lobby
+    sock, nonce = connect_local("testlobby", registry_dir=tmp_registry)
+    try:
+        assert isinstance(nonce, str) and len(nonce) > 0
+        # Drive a session_hello end-to-end: if the handshake was
+        # bad, the lobby would have closed the connection and this
+        # send/recv would see EOF.
+        sock.sendall(
+            (encode("session_hello",
+                    {"client_kind": "clive", "name": "alice"},
+                    nonce=nonce) + "\n").encode()
+        )
+        sock.settimeout(1.0)
+        data = sock.recv(4096)
+        frames = decode_all(data.decode("utf-8", errors="replace"),
+                            nonce=nonce)
+        assert frames and frames[0].kind == "session_ack"
+        assert frames[0].payload["accepted"] is True
+    finally:
+        sock.close()
+
+
+def test_explicit_nonce_is_honoured(running_lobby, tmp_registry):
+    """The caller can supply the nonce (how the SSH path will work —
+    the outer generates it and the subprocess reads it from env).
+    Here we just verify the connector does not override it."""
+    _srv, _ = running_lobby
+    sock, nonce = connect_local("testlobby", nonce="fixed123",
+                                registry_dir=tmp_registry)
+    try:
+        assert nonce == "fixed123"
+        # Sanity: frames stamped with "fixed123" are accepted.
+        sock.sendall(
+            (encode("session_hello",
+                    {"client_kind": "clive", "name": "alice"},
+                    nonce="fixed123") + "\n").encode()
+        )
+        sock.settimeout(1.0)
+        frames = decode_all(sock.recv(4096).decode(), nonce="fixed123")
+        assert frames[0].kind == "session_ack"
+    finally:
+        sock.close()
+
+
+def test_nonces_are_unique_across_calls(running_lobby, tmp_registry):
+    """Without an explicit nonce, each call must mint a fresh one.
+    Two concurrent members sharing a nonce would be a §7.2 violation
+    (compromised member could forge for the other)."""
+    _srv, _ = running_lobby
+    _, n1 = connect_local("testlobby", registry_dir=tmp_registry)
+    _, n2 = connect_local("testlobby", registry_dir=tmp_registry)
+    assert n1 != n2
+
+
+# ─── Resolution failures ────────────────────────────────────────────────────
+
+
+def test_unknown_lobby_name_raises_connect_error(tmp_registry):
+    with pytest.raises(ConnectError, match="not registered"):
+        connect_local("no-such-lobby", registry_dir=tmp_registry)
+
+
+def test_non_broker_instance_is_rejected(tmp_registry):
+    """A regular named clive is not a lobby — refuse to connect.
+    The registry carries a `role` field precisely so this check
+    is cheap and doesn't require a round-trip."""
+    import registry as _reg
+    _reg.register(
+        name="regular", pid=os.getpid(),
+        tmux_session="", tmux_socket="", toolset="", task="",
+        conversational=True, session_dir="",
+        registry_dir=tmp_registry,
+        # No role=broker.
+    )
+    with pytest.raises(ConnectError, match="not a broker"):
+        connect_local("regular", registry_dir=tmp_registry)
+
+
+def test_broker_without_socket_path_is_rejected(tmp_registry):
+    """Defensive: a registry entry declared role=broker but missing
+    socket_path cannot be connected. Would indicate a registry-schema
+    drift bug elsewhere; we should surface it loudly."""
+    import registry as _reg
+    _reg.register(
+        name="noSocket", pid=os.getpid(),
+        tmux_session="", tmux_socket="", toolset="", task="",
+        conversational=True, session_dir="",
+        registry_dir=tmp_registry,
+        role="broker",
+        # No socket_path.
+    )
+    with pytest.raises(ConnectError, match="socket_path"):
+        connect_local("noSocket", registry_dir=tmp_registry)
+
+
+def test_missing_socket_file_raises_connect_error(tmp_registry):
+    """If the socket file is gone (broker crashed uncleanly),
+    registry pruning should eventually evict the entry; until then
+    we surface the connection failure as a ConnectError rather
+    than a bare OSError."""
+    import registry as _reg
+    _reg.register(
+        name="stale", pid=os.getpid(),
+        tmux_session="", tmux_socket="", toolset="", task="",
+        conversational=True, session_dir="",
+        registry_dir=tmp_registry,
+        role="broker",
+        socket_path="/tmp/definitely-not-a-real-socket-xyz.sock",
+    )
+    with pytest.raises(ConnectError, match="cannot connect"):
+        connect_local("stale", registry_dir=tmp_registry)

--- a/tests/test_lobby_connector.py
+++ b/tests/test_lobby_connector.py
@@ -165,6 +165,26 @@ def test_broker_without_socket_path_is_rejected(tmp_registry):
         connect_local("noSocket", registry_dir=tmp_registry)
 
 
+def test_invalid_nonce_alphabet_rejected_before_connect(tmp_registry):
+    """An explicit nonce with disallowed characters must fail with a
+    clear ConnectError at the connector layer — not as a "broken
+    pipe on next send" after the lobby silently closes the socket
+    during its own handshake validation. The early-rejection keeps
+    the cause co-located with the symptom for debugging."""
+    import registry as _reg
+    _reg.register(
+        name="lobby", pid=os.getpid(),
+        tmux_session="", tmux_socket="", toolset="", task="",
+        conversational=True, session_dir="",
+        registry_dir=tmp_registry,
+        role="broker",
+        socket_path="/tmp/not-used-we-fail-first.sock",
+    )
+    with pytest.raises(ConnectError, match="disallowed characters"):
+        connect_local("lobby", nonce="bad:chars",
+                      registry_dir=tmp_registry)
+
+
 def test_missing_socket_file_raises_connect_error(tmp_registry):
     """If the socket file is gone (broker crashed uncleanly),
     registry pruning should eventually evict the entry; until then

--- a/tests/test_lobby_protocol.py
+++ b/tests/test_lobby_protocol.py
@@ -1,0 +1,256 @@
+"""Protocol-level tests for clive-rooms frame kinds and rendering.
+
+Covers the new kinds added for the lobby/rooms feature:
+  session_hello, session_ack, join_room, list_threads, threads,
+  open_thread, thread_opened, close_thread, join_thread, leave_thread,
+  your_turn, say, pass, nack.
+
+See docs/plans/2026-04-14-clive-rooms-design.md §4.
+"""
+from protocol import KINDS, encode, decode_all, Frame
+from remote import render_agent_screen, _render_frame
+
+
+ROOM_KINDS = {
+    "session_hello", "session_ack",
+    "join_room", "list_threads", "threads",
+    "open_thread", "thread_opened", "close_thread",
+    "join_thread", "leave_thread",
+    "your_turn", "say", "pass", "nack",
+}
+
+
+# ─── KINDS registration ──────────────────────────────────────────────────────
+
+def test_all_room_kinds_registered():
+    missing = ROOM_KINDS - set(KINDS)
+    assert not missing, f"room kinds not registered in KINDS: {missing}"
+
+
+# ─── Round-trip ──────────────────────────────────────────────────────────────
+
+def test_session_hello_round_trip():
+    out = encode("session_hello", {"client_kind": "clive", "name": "alice"})
+    frames = decode_all(out)
+    assert frames == [Frame(kind="session_hello",
+                            payload={"client_kind": "clive", "name": "alice"})]
+
+
+def test_session_ack_round_trip():
+    out = encode("session_ack", {"name": "alice", "accepted": True})
+    frames = decode_all(out)
+    assert frames[0].payload == {"name": "alice", "accepted": True}
+
+
+def test_session_ack_rejection_round_trip():
+    out = encode("session_ack",
+                 {"name": "alice", "accepted": False, "reason": "name_in_use"})
+    frames = decode_all(out)
+    assert frames[0].payload["reason"] == "name_in_use"
+
+
+def test_join_room_round_trip():
+    assert decode_all(encode("join_room", {"room": "general"}))[0].payload == {"room": "general"}
+
+
+def test_open_thread_round_trip():
+    payload = {
+        "room": "general",
+        "members": ["alice", "bob", "charlie"],
+        "private": False,
+        "prompt": "what's 2+2?",
+    }
+    assert decode_all(encode("open_thread", payload))[0].payload == payload
+
+
+def test_thread_opened_round_trip():
+    payload = {"thread_id": "general-t007"}
+    assert decode_all(encode("thread_opened", payload))[0].payload == payload
+
+
+def test_close_thread_round_trip():
+    payload = {"thread_id": "general-t007", "summary": "discussed pricing"}
+    assert decode_all(encode("close_thread", payload))[0].payload == payload
+
+
+def test_close_thread_without_summary():
+    payload = {"thread_id": "general-t007"}
+    assert decode_all(encode("close_thread", payload))[0].payload == payload
+
+
+def test_join_thread_round_trip():
+    payload = {"thread_id": "general-t001"}
+    assert decode_all(encode("join_thread", payload))[0].payload == payload
+
+
+def test_leave_thread_round_trip():
+    payload = {"thread_id": "general-t001"}
+    assert decode_all(encode("leave_thread", payload))[0].payload == payload
+
+
+def test_list_threads_round_trip():
+    assert decode_all(encode("list_threads", {"room": "general"}))[0].payload == {"room": "general"}
+
+
+def test_threads_response_round_trip():
+    payload = {
+        "room": "general",
+        "threads": [
+            {"thread_id": "general-t001", "initiator": "alice",
+             "members": ["alice", "bob"], "state": "open",
+             "message_count": 3, "private": False},
+        ],
+    }
+    assert decode_all(encode("threads", payload))[0].payload == payload
+
+
+def test_your_turn_carries_structured_context():
+    """§4.2: your_turn must carry thread context inline, not via scrollback."""
+    payload = {
+        "thread_id": "general-t001",
+        "room": "general",
+        "name": "alice",
+        "members": ["alice", "bob", "charlie"],
+        "message_index": 3,
+        "recent": [
+            {"from": "bob", "kind": "say", "body": "hello"},
+            {"from": "charlie", "kind": "pass"},
+        ],
+    }
+    assert decode_all(encode("your_turn", payload))[0].payload == payload
+
+
+def test_your_turn_with_summary():
+    payload = {
+        "thread_id": "general-t001",
+        "room": "general",
+        "name": "alice",
+        "members": ["alice", "bob"],
+        "message_index": 72,
+        "summary": "Earlier: discussed pricing tiers.",
+        "recent": [{"from": "bob", "kind": "say", "body": "any objections?"}],
+    }
+    assert decode_all(encode("your_turn", payload))[0].payload["summary"].startswith("Earlier:")
+
+
+def test_say_round_trip():
+    payload = {"thread_id": "general-t001", "body": "I propose option B."}
+    assert decode_all(encode("say", payload))[0].payload == payload
+
+
+def test_pass_round_trip():
+    payload = {"thread_id": "general-t001"}
+    assert decode_all(encode("pass", payload))[0].payload == payload
+
+
+def test_nack_round_trip():
+    payload = {"reason": "not_your_turn", "ref_kind": "say"}
+    assert decode_all(encode("nack", payload))[0].payload == payload
+
+
+# ─── Rendering ───────────────────────────────────────────────────────────────
+
+def test_render_say_includes_author_and_thread():
+    """Fanned-out say frames carry `from` stamped by the lobby; rendering
+    must surface both author and thread so a human reading the pane
+    transcript can follow the conversation."""
+    line = _render_frame("say", {
+        "thread_id": "general-t007",
+        "body": "I agree.",
+        "from": "alice",
+    })
+    assert "alice" in line
+    assert "general-t007" in line
+    assert "I agree." in line
+
+
+def test_render_pass_includes_author():
+    line = _render_frame("pass", {"thread_id": "general-t007", "from": "bob"})
+    assert "bob" in line
+    assert "pass" in line.lower()
+    assert "general-t007" in line
+
+
+def test_render_your_turn_suppresses_payload():
+    """§4.2: your_turn is consumed structurally by the room_runner, not
+    by LLM scrollback. Rendering must NOT dump the `recent` messages
+    into the pseudo-line or the LLM sees thread context twice."""
+    line = _render_frame("your_turn", {
+        "thread_id": "general-t007",
+        "room": "general",
+        "name": "alice",
+        "members": ["alice", "bob"],
+        "message_index": 5,
+        "recent": [{"from": "bob", "kind": "say", "body": "LONG MESSAGE BODY"}],
+    })
+    assert "your_turn" in line
+    assert "general-t007" in line
+    assert "LONG MESSAGE BODY" not in line
+    assert "recent" not in line
+
+
+def test_render_thread_opened():
+    line = _render_frame("thread_opened", {"thread_id": "general-t007"})
+    assert "thread_opened" in line
+    assert "general-t007" in line
+
+
+def test_render_nack():
+    line = _render_frame("nack", {"reason": "not_your_turn", "ref_kind": "say"})
+    assert "nack" in line.lower()
+    assert "not_your_turn" in line
+
+
+def test_render_session_ack():
+    line = _render_frame("session_ack", {"name": "alice", "accepted": True})
+    assert "session_ack" in line
+    assert "alice" in line
+
+
+def test_render_agent_screen_includes_new_kinds():
+    """End-to-end: a screen blob containing mixed frames renders each
+    known kind. Unknown or wrong-nonce frames are still dropped."""
+    screen = "\n".join([
+        encode("say", {"thread_id": "T1", "body": "hello", "from": "alice"},
+               nonce="n"),
+        "some shell output",
+        encode("pass", {"thread_id": "T1", "from": "bob"}, nonce="n"),
+        encode("your_turn", {
+            "thread_id": "T1", "room": "general", "name": "charlie",
+            "members": ["alice", "bob", "charlie"], "message_index": 2,
+            "recent": [{"from": "alice", "kind": "say", "body": "hello"}],
+        }, nonce="n"),
+    ])
+    rendered = render_agent_screen(screen, nonce="n")
+    assert "alice" in rendered           # `say from alice`
+    assert "bob" in rendered             # `pass from bob`
+    # charlie is only named in `members` / `name` of your_turn — those
+    # fields are intentionally suppressed per §4.2, so charlie MUST NOT
+    # appear in the rendered scrollback view.
+    assert "charlie" not in rendered
+    assert "your_turn" in rendered
+    assert "T1" in rendered
+    assert "some shell output" in rendered  # non-frame content preserved
+
+
+def test_render_agent_screen_drops_wrong_nonce_new_kinds():
+    """The nonce defense applies equally to new kinds. A forged say
+    frame must NOT be rendered into the LLM's view of the pane."""
+    forged = encode("say", {"thread_id": "T1", "body": "forged",
+                            "from": "attacker"}, nonce="wrong")
+    rendered = render_agent_screen(forged, nonce="expected")
+    assert "forged" not in rendered
+    assert "attacker" not in rendered
+
+
+# ─── Session hello/ack suppression semantics ─────────────────────────────────
+
+def test_session_hello_is_suppressed_for_llm():
+    """session_hello is an outbound-only frame the member emits on
+    session start; rendering it to the LLM is noise. Verify it is
+    suppressed in render_agent_screen output (even when nonce matches)."""
+    screen = encode("session_hello", {"client_kind": "clive", "name": "alice"},
+                    nonce="n")
+    rendered = render_agent_screen(screen, nonce="n")
+    # Frame is stripped; pseudo-line would contain 'session_hello'
+    assert "session_hello" not in rendered

--- a/tests/test_lobby_server.py
+++ b/tests/test_lobby_server.py
@@ -1,0 +1,369 @@
+"""Integration tests for the lobby IO layer (Phase 2).
+
+These tests spin up the selectors-based lobby server on an ephemeral
+Unix socket, connect raw clients, and drive the session-layer
+handshake and a few of the simpler dispatch paths end-to-end. Rooms
+and threads themselves live in the pure state machine and are covered
+by ``test_lobby_state.py``; here we validate only what the IO layer
+adds: socket accept, per-connection nonce handshake, framed IO, frame
+dispatch, and clean session drop.
+
+See docs/plans/2026-04-14-clive-rooms-design.md §5 (lobby
+implementation) and §11 Phase 2.
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from protocol import Frame, decode_all, encode
+from lobby_server import LobbyServer
+
+
+# ─── Harness ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_socket():
+    # macOS caps AF_UNIX paths near 104 chars, shorter than pytest's
+    # default tmp_path. Use a short name under the system tmpdir.
+    fd, p = tempfile.mkstemp(prefix="clv-", suffix=".sock")
+    os.close(fd)
+    os.unlink(p)   # server will create it
+    try:
+        yield p
+    finally:
+        try:
+            os.unlink(p)
+        except FileNotFoundError:
+            pass
+
+
+@pytest.fixture
+def tmp_registry(tmp_path: Path):
+    d = tmp_path / "instances"
+    d.mkdir()
+    yield d
+
+
+@pytest.fixture
+def server(tmp_socket, tmp_registry):
+    """A started-but-not-running server. Tests call ``start_thread()``."""
+    srv = LobbyServer(
+        socket_path=tmp_socket,
+        registry_dir=tmp_registry,
+        instance_name="test-lobby",
+    )
+    srv.start()
+    t = threading.Thread(target=srv.run_forever, name="lobby", daemon=True)
+    t.start()
+    yield srv
+    srv.shutdown()
+    t.join(timeout=2.0)
+
+
+def _connect(socket_path: str, nonce: str) -> socket.socket:
+    """Open a Unix socket and complete the nonce handshake. Returns the
+    connected socket ready for framed IO."""
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    # The server socket is created inside the fixture's thread; retry
+    # briefly if it hasn't appeared yet.
+    for _ in range(50):
+        try:
+            s.connect(socket_path)
+            break
+        except (FileNotFoundError, ConnectionRefusedError):
+            time.sleep(0.02)
+    else:
+        raise RuntimeError(f"lobby socket never appeared at {socket_path}")
+    s.sendall(f"NONCE {nonce}\n".encode())
+    return s
+
+
+def _recv_frames(s: socket.socket, nonce: str, *, timeout: float = 1.0) -> list[Frame]:
+    """Read one chunk from the socket and decode frames."""
+    s.settimeout(timeout)
+    data = b""
+    # Read until we see at least one terminator or timeout.
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            chunk = s.recv(4096)
+        except socket.timeout:
+            break
+        if not chunk:
+            break
+        data += chunk
+        if b">>>" in data:
+            # Likely got a full frame; keep reading briefly for trailing ones.
+            s.settimeout(0.05)
+            try:
+                while True:
+                    more = s.recv(4096)
+                    if not more:
+                        break
+                    data += more
+            except socket.timeout:
+                pass
+            break
+    return decode_all(data.decode("utf-8", errors="replace"), nonce=nonce)
+
+
+# ─── Socket lifecycle / registry ─────────────────────────────────────────────
+
+
+def test_server_creates_socket_and_registry_entry(server, tmp_socket, tmp_registry):
+    # Socket exists and is a socket.
+    assert Path(tmp_socket).exists()
+    assert Path(tmp_socket).is_socket()
+    # Registry entry exists with role=broker.
+    entries = list(tmp_registry.glob("*.json"))
+    assert len(entries) == 1
+    data = json.loads(entries[0].read_text())
+    assert data["name"] == "test-lobby"
+    assert data["role"] == "broker"
+
+
+def test_server_removes_socket_on_shutdown(tmp_socket, tmp_registry):
+    srv = LobbyServer(socket_path=tmp_socket, registry_dir=tmp_registry,
+                      instance_name="shutdown-lobby")
+    srv.start()
+    t = threading.Thread(target=srv.run_forever, daemon=True)
+    t.start()
+    assert Path(tmp_socket).exists()
+    srv.shutdown()
+    t.join(timeout=2.0)
+    assert not Path(tmp_socket).exists()
+    # Registry deregistered too.
+    assert not (tmp_registry / "shutdown-lobby.json").exists()
+
+
+# ─── Handshake ───────────────────────────────────────────────────────────────
+
+
+def test_session_hello_accepted(server, tmp_socket):
+    s = _connect(tmp_socket, nonce="n1")
+    s.sendall((encode("session_hello",
+                      {"client_kind": "clive", "name": "alice"},
+                      nonce="n1") + "\n").encode())
+    frames = _recv_frames(s, nonce="n1")
+    assert len(frames) == 1
+    assert frames[0].kind == "session_ack"
+    assert frames[0].payload == {"name": "alice", "accepted": True}
+    s.close()
+
+
+def test_session_hello_wrong_nonce_is_dropped(server, tmp_socket):
+    """Frame with a nonce that does not match the session's declared
+    nonce must be dropped silently (no ack, no nack). The client should
+    see no response until it sends a correctly-nonced frame."""
+    s = _connect(tmp_socket, nonce="real")
+    # Send a session_hello stamped with the wrong nonce.
+    s.sendall((encode("session_hello",
+                      {"client_kind": "clive", "name": "alice"},
+                      nonce="wrong") + "\n").encode())
+    # Nothing should come back.
+    assert _recv_frames(s, nonce="real", timeout=0.3) == []
+    # Now send a correctly-nonced hello — it should succeed.
+    s.sendall((encode("session_hello",
+                      {"client_kind": "clive", "name": "alice"},
+                      nonce="real") + "\n").encode())
+    frames = _recv_frames(s, nonce="real")
+    assert frames[0].kind == "session_ack"
+    assert frames[0].payload["accepted"] is True
+    s.close()
+
+
+def test_name_in_use_rejection(server, tmp_socket):
+    a = _connect(tmp_socket, nonce="nA")
+    a.sendall((encode("session_hello",
+                      {"client_kind": "clive", "name": "alice"},
+                      nonce="nA") + "\n").encode())
+    assert _recv_frames(a, nonce="nA")[0].payload["accepted"] is True
+
+    b = _connect(tmp_socket, nonce="nB")
+    b.sendall((encode("session_hello",
+                      {"client_kind": "clive", "name": "alice"},
+                      nonce="nB") + "\n").encode())
+    frames = _recv_frames(b, nonce="nB")
+    assert frames[0].kind == "session_ack"
+    assert frames[0].payload["accepted"] is False
+    assert frames[0].payload["reason"] == "name_in_use"
+    a.close()
+    b.close()
+
+
+def test_name_freed_on_disconnect(server, tmp_socket):
+    a = _connect(tmp_socket, nonce="nA")
+    a.sendall((encode("session_hello",
+                      {"client_kind": "clive", "name": "alice"},
+                      nonce="nA") + "\n").encode())
+    assert _recv_frames(a, nonce="nA")[0].payload["accepted"] is True
+    a.close()
+    # Give the server a moment to detect the close.
+    time.sleep(0.1)
+    b = _connect(tmp_socket, nonce="nB")
+    b.sendall((encode("session_hello",
+                      {"client_kind": "clive", "name": "alice"},
+                      nonce="nB") + "\n").encode())
+    frames = _recv_frames(b, nonce="nB")
+    assert frames[0].payload["accepted"] is True
+    b.close()
+
+
+def test_pre_hello_frame_is_nacked(server, tmp_socket):
+    """Any non-hello frame before session_hello returns
+    session_hello_required per lobby_state dispatch."""
+    s = _connect(tmp_socket, nonce="n")
+    s.sendall((encode("join_room", {"room": "general"}, nonce="n") + "\n").encode())
+    frames = _recv_frames(s, nonce="n")
+    assert frames[0].kind == "nack"
+    assert frames[0].payload == {
+        "reason": "session_hello_required", "ref_kind": "join_room",
+    }
+    s.close()
+
+
+def test_alive_frames_are_silently_accepted(server, tmp_socket):
+    """Lobby must not nack `alive` frames — they are the keepalive
+    ticker emission and should be absorbed without response."""
+    s = _connect(tmp_socket, nonce="n")
+    s.sendall((encode("session_hello",
+                      {"client_kind": "clive", "name": "alice"},
+                      nonce="n") + "\n").encode())
+    assert _recv_frames(s, nonce="n")[0].kind == "session_ack"
+    s.sendall((encode("alive", {"ts": 1.0}, nonce="n") + "\n").encode())
+    assert _recv_frames(s, nonce="n", timeout=0.3) == []
+    s.close()
+
+
+def test_unknown_kind_is_nacked(server, tmp_socket):
+    """A valid-format frame whose kind is not handled by the lobby
+    (e.g. `context`, which is meaningful inside a clive pane but not
+    to the lobby) is nacked with reason=unknown_kind."""
+    s = _connect(tmp_socket, nonce="n")
+    s.sendall((encode("session_hello",
+                      {"client_kind": "clive", "name": "alice"},
+                      nonce="n") + "\n").encode())
+    assert _recv_frames(s, nonce="n")[0].kind == "session_ack"
+    s.sendall((encode("context", {"foo": "bar"}, nonce="n") + "\n").encode())
+    frames = _recv_frames(s, nonce="n")
+    assert frames[0].kind == "nack"
+    assert frames[0].payload["reason"] == "unknown_kind"
+    assert frames[0].payload["ref_kind"] == "context"
+    s.close()
+
+
+# ─── Multiple concurrent connections ─────────────────────────────────────────
+
+
+def test_two_sessions_get_independent_nonces(server, tmp_socket):
+    """Each session has its own nonce. A fanout-style send from the
+    server must reach the intended recipient under that recipient's
+    nonce. We can't test fanout without rooms (Phase 3), so here we
+    just verify two sessions don't bleed frames into each other."""
+    a = _connect(tmp_socket, nonce="nA")
+    b = _connect(tmp_socket, nonce="nB")
+    a.sendall((encode("session_hello",
+                      {"client_kind": "clive", "name": "alice"},
+                      nonce="nA") + "\n").encode())
+    b.sendall((encode("session_hello",
+                      {"client_kind": "clive", "name": "bob"},
+                      nonce="nB") + "\n").encode())
+    af = _recv_frames(a, nonce="nA")
+    bf = _recv_frames(b, nonce="nB")
+    assert af[0].payload == {"name": "alice", "accepted": True}
+    assert bf[0].payload == {"name": "bob", "accepted": True}
+    # Cross-decode: B's reply cannot be decoded with A's nonce.
+    assert _recv_frames(a, nonce="nB", timeout=0.1) == []
+    a.close()
+    b.close()
+
+
+def test_lobby_client_wrapper_round_trip(server, tmp_socket):
+    """End-to-end: the lobby_client wrapper (SSH-invoked bridge) pipes
+    a local stdin/stdout pair through to the server and back. Proves
+    the wire format (NONCE line + framed lines) is consistent between
+    server and client."""
+    from lobby_client import run as _run
+
+    # We drive the wrapper on two OS pipes.
+    stdin_r, stdin_w = os.pipe()
+    stdout_r, stdout_w = os.pipe()
+
+    def _client():
+        # Stand in for stdin/stdout.buffer: raw fd files.
+        with os.fdopen(stdin_r, "rb", buffering=0) as fin, \
+             os.fdopen(stdout_w, "wb", buffering=0) as fout:
+            _run(socket_path=tmp_socket, nonce="nc", stdin=fin, stdout=fout)
+
+    t = threading.Thread(target=_client, daemon=True)
+    t.start()
+
+    try:
+        os.write(stdin_w, (encode("session_hello",
+                                  {"client_kind": "clive", "name": "alice"},
+                                  nonce="nc") + "\n").encode())
+        # Read reply from the wrapper's stdout end.
+        deadline = time.time() + 2.0
+        buf = b""
+        while time.time() < deadline:
+            try:
+                chunk = os.read(stdout_r, 4096)
+            except BlockingIOError:
+                time.sleep(0.02)
+                continue
+            if not chunk:
+                break
+            buf += chunk
+            if b">>>" in buf:
+                break
+        frames = decode_all(buf.decode("utf-8", errors="replace"), nonce="nc")
+        assert frames and frames[0].kind == "session_ack"
+        assert frames[0].payload["accepted"] is True
+    finally:
+        os.close(stdin_w)
+        # Drain any remaining wrapper output so the thread can exit.
+        try:
+            os.close(stdout_r)
+        except OSError:
+            pass
+        t.join(timeout=2.0)
+
+
+def test_missing_nonce_line_closes_connection(server, tmp_socket):
+    """Clients that never send the NONCE handshake line must not
+    starve the server. Sending raw frames without a handshake is a
+    protocol violation; the server closes the socket."""
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    for _ in range(50):
+        try:
+            s.connect(tmp_socket)
+            break
+        except (FileNotFoundError, ConnectionRefusedError):
+            time.sleep(0.02)
+    # Send a frame with no prior NONCE line.
+    s.sendall((encode("session_hello",
+                      {"client_kind": "clive", "name": "alice"},
+                      nonce="") + "\n").encode())
+    # Server should close shortly; recv returns empty.
+    s.settimeout(1.0)
+    data = b""
+    try:
+        while True:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+    except socket.timeout:
+        pass
+    s.close()
+    # No session_ack because no hello was processed under any valid nonce.
+    assert b"session_ack" not in data

--- a/tests/test_lobby_server.py
+++ b/tests/test_lobby_server.py
@@ -131,6 +131,41 @@ def test_server_creates_socket_and_registry_entry(server, tmp_socket, tmp_regist
     assert data["role"] == "broker"
 
 
+def test_second_broker_with_same_name_is_rejected(server, tmp_registry):
+    """A second LobbyServer.start() under the same instance name must
+    refuse to run — otherwise it would unlink the first broker's
+    socket and overwrite its registry entry, silently killing
+    connectivity for every already-connected client."""
+    fd, p2 = tempfile.mkstemp(prefix="clv-", suffix=".sock")
+    os.close(fd)
+    os.unlink(p2)
+    try:
+        srv2 = LobbyServer(
+            socket_path=p2,
+            registry_dir=tmp_registry,
+            instance_name="test-lobby",   # same as `server` fixture
+        )
+        with pytest.raises(RuntimeError, match="already running"):
+            srv2.start()
+        # The second server must NOT have created its socket.
+        assert not Path(p2).exists()
+    finally:
+        try:
+            os.unlink(p2)
+        except FileNotFoundError:
+            pass
+
+
+def test_socket_is_owner_only(server, tmp_socket):
+    """The socket file must be 0o600 — world-readable would let any
+    local user connect and speak the lobby protocol, bypassing the
+    SSH auth gate. The umask-tightening + chmod defence-in-depth
+    together should guarantee the mode."""
+    import stat
+    mode = stat.S_IMODE(os.stat(tmp_socket).st_mode)
+    assert mode == 0o600, f"socket mode is {oct(mode)}, want 0o600"
+
+
 def test_server_removes_socket_on_shutdown(tmp_socket, tmp_registry):
     srv = LobbyServer(socket_path=tmp_socket, registry_dir=tmp_registry,
                       instance_name="shutdown-lobby")
@@ -341,7 +376,7 @@ def test_lobby_client_wrapper_round_trip(server, tmp_socket):
 def test_missing_nonce_line_closes_connection(server, tmp_socket):
     """Clients that never send the NONCE handshake line must not
     starve the server. Sending raw frames without a handshake is a
-    protocol violation; the server closes the socket."""
+    protocol violation; the server closes the socket promptly."""
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     for _ in range(50):
         try:
@@ -353,17 +388,17 @@ def test_missing_nonce_line_closes_connection(server, tmp_socket):
     s.sendall((encode("session_hello",
                       {"client_kind": "clive", "name": "alice"},
                       nonce="") + "\n").encode())
-    # Server should close shortly; recv returns empty.
+    # Server must close the socket; recv() should return b"" quickly.
+    # If the earlier assertion had only checked "no session_ack" we
+    # would have passed trivially even for a hanging server — this
+    # version pins down both the close AND the latency.
     s.settimeout(1.0)
-    data = b""
+    start = time.time()
     try:
-        while True:
-            chunk = s.recv(4096)
-            if not chunk:
-                break
-            data += chunk
+        data = s.recv(4096)
     except socket.timeout:
-        pass
+        data = b"__TIMEOUT__"
+    elapsed = time.time() - start
     s.close()
-    # No session_ack because no hello was processed under any valid nonce.
-    assert b"session_ack" not in data
+    assert data == b"", f"server did not close, received: {data!r}"
+    assert elapsed < 0.9, f"close took too long: {elapsed:.3f}s"

--- a/tests/test_lobby_server.py
+++ b/tests/test_lobby_server.py
@@ -373,6 +373,179 @@ def test_lobby_client_wrapper_round_trip(server, tmp_socket):
         t.join(timeout=2.0)
 
 
+# ─── End-to-end rooms flow over the wire (Phase 3 verification) ─────────────
+
+
+def _hello(s: socket.socket, nonce: str, name: str, kind: str = "clive") -> None:
+    s.sendall((encode("session_hello", {"client_kind": kind, "name": name},
+                      nonce=nonce) + "\n").encode())
+
+
+def _send(s: socket.socket, nonce: str, kind: str, payload: dict) -> None:
+    s.sendall((encode(kind, payload, nonce=nonce) + "\n").encode())
+
+
+def _drain(s: socket.socket, nonce: str, want_kinds: set[str],
+           *, timeout: float = 1.0) -> list[Frame]:
+    """Read from `s` until all frame kinds in `want_kinds` have been
+    seen at least once, or the timeout expires. Returns all frames
+    seen. Fails loudly on timeout so the assertion message pinpoints
+    which kind was missing."""
+    s.settimeout(timeout)
+    data = b""
+    seen: set[str] = set()
+    deadline = time.time() + timeout
+    while want_kinds - seen and time.time() < deadline:
+        try:
+            chunk = s.recv(4096)
+        except socket.timeout:
+            break
+        if not chunk:
+            break
+        data += chunk
+        frames = decode_all(data.decode("utf-8", errors="replace"), nonce=nonce)
+        seen = {f.kind for f in frames}
+    frames = decode_all(data.decode("utf-8", errors="replace"), nonce=nonce)
+    missing = want_kinds - {f.kind for f in frames}
+    assert not missing, (
+        f"timeout waiting for kinds {sorted(missing)}; "
+        f"got {[(f.kind, f.payload) for f in frames]}"
+    )
+    return frames
+
+
+def test_end_to_end_thread_rotation(server, tmp_socket):
+    """Two clives open a thread in `general`, exchange one say and one
+    pass, then close. Exercises the full lobby_server + lobby_state
+    composition: socket IO, per-session nonces, room membership,
+    thread opening with prompt, fanout to room observers, your_turn
+    routing, pass rotation, close_thread authorization.
+
+    This is the first test that proves phase 2 IO correctly wires up
+    phase 2's pure state machine — the state-machine tests can't see
+    nonce stamping or socket routing; the protocol tests can't see
+    rotation. This one does."""
+    a = _connect(tmp_socket, nonce="nA")
+    b = _connect(tmp_socket, nonce="nB")
+
+    _hello(a, "nA", "alice")
+    _hello(b, "nB", "bob")
+    assert _drain(a, "nA", {"session_ack"})[0].payload["accepted"] is True
+    assert _drain(b, "nB", {"session_ack"})[0].payload["accepted"] is True
+
+    _send(a, "nA", "join_room", {"room": "general"})
+    _send(b, "nB", "join_room", {"room": "general"})
+    # join_room is silent on success — no frames to drain. Give the
+    # server a moment to process so membership is in place before
+    # alice opens the thread.
+    time.sleep(0.05)
+
+    # Alice opens a thread with both members and a prompt. State
+    # machine treats the prompt as alice's first `say`, fans it out,
+    # advances cursor to bob, and sends your_turn to bob.
+    _send(a, "nA", "open_thread", {
+        "room": "general",
+        "members": ["alice", "bob"],
+        "private": False,
+        "prompt": "what's 2+2?",
+    })
+
+    # Alice should see: thread_opened (confirming creation). The `say`
+    # fanout goes to bob (and to any room observer that isn't the
+    # sender) but NOT back to alice — fanout skips sender. Alice also
+    # does NOT get your_turn here because cursor advanced to bob.
+    a_frames = _drain(a, "nA", {"thread_opened"})
+    opened = next(f for f in a_frames if f.kind == "thread_opened")
+    thread_id = opened.payload["thread_id"]
+    assert thread_id.startswith("general-t")
+
+    # Bob should see: the say fanout from alice (with the prompt) AND
+    # his own your_turn.
+    b_frames = _drain(b, "nB", {"say", "your_turn"})
+    say_fanout = next(f for f in b_frames if f.kind == "say")
+    assert say_fanout.payload["body"] == "what's 2+2?"
+    assert say_fanout.payload["from"] == "alice"
+    assert say_fanout.payload["thread_id"] == thread_id
+    your_turn = next(f for f in b_frames if f.kind == "your_turn")
+    assert your_turn.payload["thread_id"] == thread_id
+    assert your_turn.payload["name"] == "bob"
+    assert your_turn.payload["members"] == ["alice", "bob"]
+    # `recent` must include the opening prompt (structured context per §4.2).
+    recent = your_turn.payload["recent"]
+    assert any(m.get("body") == "what's 2+2?" for m in recent)
+
+    # Bob says "4". State machine fans out to alice (and room
+    # observers), advances cursor back to alice, sends your_turn.
+    _send(b, "nB", "say", {"thread_id": thread_id, "body": "4"})
+    a_frames2 = _drain(a, "nA", {"say", "your_turn"})
+    say_from_bob = next(f for f in a_frames2 if f.kind == "say")
+    assert say_from_bob.payload["from"] == "bob"
+    assert say_from_bob.payload["body"] == "4"
+
+    # Alice passes. State machine fans out pass to bob and advances
+    # cursor back to bob with another your_turn.
+    _send(a, "nA", "pass", {"thread_id": thread_id})
+    b_frames2 = _drain(b, "nB", {"pass", "your_turn"})
+    pass_frame = next(f for f in b_frames2 if f.kind == "pass")
+    assert pass_frame.payload["from"] == "alice"
+    assert pass_frame.payload["thread_id"] == thread_id
+
+    # Alice closes the thread (she is the initiator, so authorized).
+    _send(a, "nA", "close_thread", {"thread_id": thread_id,
+                                    "summary": "done"})
+    # close_thread has no explicit ack in v1; the thread just transitions
+    # to closed in state. Verify no nack came back.
+    time.sleep(0.1)
+    a.settimeout(0.1)
+    try:
+        leftover = a.recv(4096)
+    except socket.timeout:
+        leftover = b""
+    frames = decode_all(leftover.decode("utf-8", errors="replace"), nonce="nA")
+    nacks = [f for f in frames if f.kind == "nack"]
+    assert not nacks, f"unexpected nacks: {[f.payload for f in nacks]}"
+
+    a.close()
+    b.close()
+
+
+def test_non_initiator_cannot_close_thread(server, tmp_socket):
+    """Authorization test that is cheapest to drive end-to-end rather
+    than at the state-machine level, because it exercises nonce
+    stamping on the nack coming back on bob's connection under his
+    own nonce."""
+    a = _connect(tmp_socket, nonce="nA")
+    b = _connect(tmp_socket, nonce="nB")
+    _hello(a, "nA", "alice")
+    _hello(b, "nB", "bob")
+    _drain(a, "nA", {"session_ack"})
+    _drain(b, "nB", {"session_ack"})
+    _send(a, "nA", "join_room", {"room": "general"})
+    _send(b, "nB", "join_room", {"room": "general"})
+    time.sleep(0.05)
+    _send(a, "nA", "open_thread", {
+        "room": "general",
+        "members": ["alice", "bob"],
+        "private": False,
+        "prompt": "hi",
+    })
+    a_frames = _drain(a, "nA", {"thread_opened"})
+    thread_id = next(f for f in a_frames
+                     if f.kind == "thread_opened").payload["thread_id"]
+    # Drain bob's your_turn so we start from a clean line.
+    _drain(b, "nB", {"your_turn"})
+
+    # Bob (non-initiator) tries to close. Must be nacked back on
+    # bob's own socket, under bob's nonce.
+    _send(b, "nB", "close_thread", {"thread_id": thread_id})
+    b_frames = _drain(b, "nB", {"nack"})
+    nack = next(f for f in b_frames if f.kind == "nack")
+    assert nack.payload["ref_kind"] == "close_thread"
+    assert "not_initiator" in nack.payload["reason"]
+    a.close()
+    b.close()
+
+
 def test_missing_nonce_line_closes_connection(server, tmp_socket):
     """Clients that never send the NONCE handshake line must not
     starve the server. Sending raw frames without a handshake is a

--- a/tests/test_lobby_state.py
+++ b/tests/test_lobby_state.py
@@ -1,0 +1,451 @@
+"""Pure state-machine tests for the lobby (rooms phase 2).
+
+Each test constructs a LobbyState, registers one or more sessions,
+drives the state machine with Frame instances, and asserts on the
+returned Send list + resulting in-memory state. No IO, no sleeps, no
+tmux, no network.
+
+See docs/plans/2026-04-14-clive-rooms-design.md §3–§4.
+"""
+from protocol import Frame
+from lobby_state import (
+    LobbyState, Send, handle,
+)
+
+
+def _send(state: LobbyState, sid: int, kind: str, payload: dict,
+          now: float = 0.0) -> list[Send]:
+    return handle(state, sid, Frame(kind=kind, payload=payload), now=now)
+
+
+def _hello(state: LobbyState, sid: int, name: str,
+           client_kind: str = "clive") -> list[Send]:
+    state.register_session(sid)
+    return _send(state, sid, "session_hello",
+                 {"client_kind": client_kind, "name": name})
+
+
+def _bootstrap(state: LobbyState, room: str, *named_sessions: tuple[int, str]):
+    """Register N sessions with names, all joined to ``room``."""
+    for sid, name in named_sessions:
+        _hello(state, sid, name)
+        _send(state, sid, "join_room", {"room": room})
+
+
+def _outbound_by_kind(sends: list[Send], kind: str) -> list[Send]:
+    return [s for s in sends if s.kind == kind]
+
+
+# ─── session_hello / session_ack ──────────────────────────────────────────────
+
+def test_session_hello_accepts_and_claims_name():
+    s = LobbyState()
+    s.register_session(1)
+    out = _send(s, 1, "session_hello", {"client_kind": "clive", "name": "alice"})
+    assert out == [Send(1, "session_ack", {"name": "alice", "accepted": True})]
+    assert s.sessions[1].name == "alice"
+    assert s.sessions[1].client_kind == "clive"
+    assert s.name_to_session["alice"] == 1
+
+
+def test_session_hello_rejects_duplicate_name():
+    s = LobbyState()
+    _hello(s, 1, "alice")
+    s.register_session(2)
+    out = _send(s, 2, "session_hello", {"client_kind": "clive", "name": "alice"})
+    assert len(out) == 1
+    assert out[0].kind == "session_ack"
+    assert out[0].payload["accepted"] is False
+    assert out[0].payload["reason"] == "name_in_use"
+    assert s.sessions[2].name == ""  # unchanged
+
+
+def test_session_hello_rejects_invalid_client_kind():
+    s = LobbyState()
+    s.register_session(1)
+    out = _send(s, 1, "session_hello", {"client_kind": "robot", "name": "x"})
+    assert out[0].payload["accepted"] is False
+    assert "client_kind" in out[0].payload["reason"]
+
+
+def test_session_hello_idempotent_on_same_session():
+    s = LobbyState()
+    _hello(s, 1, "alice")
+    out = _send(s, 1, "session_hello", {"client_kind": "clive", "name": "alice"})
+    assert out[0].payload["accepted"] is True
+
+
+def test_frame_before_session_hello_is_nacked():
+    s = LobbyState()
+    s.register_session(1)
+    out = _send(s, 1, "join_room", {"room": "general"})
+    assert len(out) == 1
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"] == "session_hello_required"
+
+
+def test_drop_session_frees_name():
+    s = LobbyState()
+    _hello(s, 1, "alice")
+    s.drop_session(1)
+    assert "alice" not in s.name_to_session
+    # Name is now re-claimable by a different session.
+    _hello(s, 2, "alice")
+    assert s.name_to_session["alice"] == 2
+
+
+# ─── join_room ────────────────────────────────────────────────────────────────
+
+def test_join_room_adds_membership_silently():
+    s = LobbyState()
+    _hello(s, 1, "alice")
+    out = _send(s, 1, "join_room", {"room": "general"})
+    assert out == []
+    assert "alice" in s.rooms["general"].member_names
+    assert "general" in s.sessions[1].joined_rooms
+
+
+def test_join_room_missing_room_field():
+    s = LobbyState()
+    _hello(s, 1, "alice")
+    out = _send(s, 1, "join_room", {})
+    assert out[0].kind == "nack"
+
+
+# ─── open_thread validation ───────────────────────────────────────────────────
+
+def test_open_thread_requires_initiator_in_room():
+    s = LobbyState()
+    _hello(s, 1, "alice")
+    s.ensure_room("general")
+    out = _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice"], "private": False, "prompt": "hi",
+    })
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"] == "not_in_room"
+
+
+def test_open_thread_requires_initiator_first_member():
+    s = LobbyState()
+    _bootstrap(s, "general", (1, "alice"), (2, "bob"))
+    out = _send(s, 1, "open_thread", {
+        "room": "general", "members": ["bob", "alice"], "private": False, "prompt": "",
+    })
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"] == "initiator_must_be_first"
+
+
+def test_open_thread_rejects_members_not_in_room():
+    s = LobbyState()
+    _bootstrap(s, "general", (1, "alice"))
+    out = _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice", "ghost"], "private": False, "prompt": "",
+    })
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"].startswith("members_not_in_room")
+
+
+def test_open_thread_rejects_duplicate_members():
+    s = LobbyState()
+    _bootstrap(s, "general", (1, "alice"), (2, "bob"))
+    out = _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice", "bob", "alice"],
+        "private": False, "prompt": "",
+    })
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"] == "duplicate_members"
+
+
+# ─── open_thread happy paths ──────────────────────────────────────────────────
+
+def test_open_thread_with_no_prompt_grants_initiator_turn():
+    s = LobbyState()
+    _bootstrap(s, "general", (1, "alice"), (2, "bob"))
+    out = _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice", "bob"], "private": False, "prompt": "",
+    })
+    opened = _outbound_by_kind(out, "thread_opened")
+    turn = _outbound_by_kind(out, "your_turn")
+    assert len(opened) == 1
+    assert opened[0].payload["thread_id"] == "general-t001"
+    assert len(turn) == 1
+    assert turn[0].session_id == 1  # alice receives the turn
+    assert turn[0].payload["name"] == "alice"
+    assert turn[0].payload["members"] == ["alice", "bob"]
+    assert turn[0].payload["recent"] == []
+
+
+def test_open_thread_with_prompt_fans_out_and_grants_second_member_turn():
+    s = LobbyState()
+    _bootstrap(s, "general", (1, "alice"), (2, "bob"), (3, "charlie"))
+    out = _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice", "bob", "charlie"],
+        "private": False, "prompt": "opening move",
+    })
+    # alice gets thread_opened, bob+charlie get the fanned-out `say`,
+    # bob (cursor advanced to 1) gets `your_turn`.
+    opened = _outbound_by_kind(out, "thread_opened")
+    says = _outbound_by_kind(out, "say")
+    turns = _outbound_by_kind(out, "your_turn")
+    assert len(opened) == 1
+    assert {s.session_id for s in says} == {2, 3}
+    assert all(s.payload["from"] == "alice" for s in says)
+    assert all(s.payload["body"] == "opening move" for s in says)
+    assert len(turns) == 1
+    assert turns[0].session_id == 2  # bob
+    assert turns[0].payload["name"] == "bob"
+    # your_turn carries the opening prompt in recent
+    assert turns[0].payload["recent"] == [
+        {"from": "alice", "kind": "say", "body": "opening move"}
+    ]
+
+
+def test_open_thread_generates_monotonic_ids_per_room():
+    s = LobbyState()
+    _bootstrap(s, "general", (1, "alice"))
+    out1 = _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice"], "private": False, "prompt": "",
+    })
+    out2 = _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice"], "private": False, "prompt": "",
+    })
+    assert _outbound_by_kind(out1, "thread_opened")[0].payload["thread_id"] == "general-t001"
+    assert _outbound_by_kind(out2, "thread_opened")[0].payload["thread_id"] == "general-t002"
+
+
+# ─── say / pass / rotation ────────────────────────────────────────────────────
+
+def _open_thread_abc(s: LobbyState, prompt: str = "start") -> str:
+    """Helper: open a thread with alice, bob, charlie."""
+    _bootstrap(s, "general", (1, "alice"), (2, "bob"), (3, "charlie"))
+    out = _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice", "bob", "charlie"],
+        "private": False, "prompt": prompt,
+    })
+    return _outbound_by_kind(out, "thread_opened")[0].payload["thread_id"]
+
+
+def test_say_out_of_turn_is_nacked():
+    s = LobbyState()
+    tid = _open_thread_abc(s)
+    # It's bob's turn (cursor advanced past alice after the prompt).
+    # charlie attempts to say → nack.
+    out = _send(s, 3, "say", {"thread_id": tid, "body": "me first"})
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"] == "not_your_turn"
+
+
+def test_say_current_speaker_advances_rotation():
+    s = LobbyState()
+    tid = _open_thread_abc(s)
+    # bob speaks.
+    out = _send(s, 2, "say", {"thread_id": tid, "body": "bob here"})
+    says = _outbound_by_kind(out, "say")
+    turns = _outbound_by_kind(out, "your_turn")
+    # Fan-out to alice + charlie, your_turn to charlie.
+    assert {s.session_id for s in says} == {1, 3}
+    assert len(turns) == 1 and turns[0].session_id == 3
+    assert turns[0].payload["recent"][-1] == {"from": "bob", "kind": "say", "body": "bob here"}
+
+
+def test_pass_advances_rotation():
+    s = LobbyState()
+    tid = _open_thread_abc(s)
+    out = _send(s, 2, "pass", {"thread_id": tid})
+    passes = _outbound_by_kind(out, "pass")
+    turns = _outbound_by_kind(out, "your_turn")
+    assert {s.session_id for s in passes} == {1, 3}
+    assert len(turns) == 1 and turns[0].session_id == 3
+
+
+def test_consecutive_passes_reach_quiescence():
+    """A full rotation of passes → thread dormant, no further your_turn."""
+    s = LobbyState()
+    tid = _open_thread_abc(s, prompt="")  # no prompt → alice starts
+    # alice pass, bob pass, charlie pass → cursor back at alice → dormant.
+    _send(s, 1, "pass", {"thread_id": tid})
+    _send(s, 2, "pass", {"thread_id": tid})
+    out = _send(s, 3, "pass", {"thread_id": tid})
+    assert s.threads[tid].state == "dormant"
+    # No new your_turn should be emitted on the closing pass.
+    assert _outbound_by_kind(out, "your_turn") == []
+
+
+def test_say_resets_pass_streak():
+    s = LobbyState()
+    tid = _open_thread_abc(s, prompt="")
+    _send(s, 1, "pass", {"thread_id": tid})
+    _send(s, 2, "say", {"thread_id": tid, "body": "hold on"})
+    # After bob's say, consecutive_passes reset; thread must stay open.
+    assert s.threads[tid].state == "open"
+    assert s.threads[tid].consecutive_passes == 0
+
+
+def test_say_on_closed_thread_is_nacked():
+    s = LobbyState()
+    tid = _open_thread_abc(s)
+    # Alice closes the thread.
+    _send(s, 1, "close_thread", {"thread_id": tid})
+    out = _send(s, 2, "say", {"thread_id": tid, "body": "wait"})
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"] == "thread_closed"
+
+
+def test_say_body_required():
+    s = LobbyState()
+    tid = _open_thread_abc(s)
+    out = _send(s, 2, "say", {"thread_id": tid, "body": ""})
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"] == "invalid_body"
+
+
+# ─── list_threads & private visibility ───────────────────────────────────────
+
+def test_list_threads_public_visible_to_all_room_members():
+    s = LobbyState()
+    _bootstrap(s, "general", (1, "alice"), (2, "bob"))
+    _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice", "bob"], "private": False,
+        "prompt": "",
+    })
+    out = _send(s, 2, "list_threads", {"room": "general"})
+    resp = _outbound_by_kind(out, "threads")[0]
+    assert len(resp.payload["threads"]) == 1
+    assert resp.payload["threads"][0]["thread_id"] == "general-t001"
+
+
+def test_list_threads_hides_private_from_non_members():
+    s = LobbyState()
+    _bootstrap(s, "general", (1, "alice"), (2, "bob"), (3, "charlie"))
+    # Private thread with alice + bob; charlie is NOT a member.
+    _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice", "bob"], "private": True,
+        "prompt": "",
+    })
+    # Member sees it.
+    out_bob = _send(s, 2, "list_threads", {"room": "general"})
+    assert len(_outbound_by_kind(out_bob, "threads")[0].payload["threads"]) == 1
+    # Non-member does NOT.
+    out_charlie = _send(s, 3, "list_threads", {"room": "general"})
+    assert _outbound_by_kind(out_charlie, "threads")[0].payload["threads"] == []
+
+
+# ─── join_thread / leave_thread / close_thread ───────────────────────────────
+
+def test_join_thread_public_appends_at_end():
+    s = LobbyState()
+    _bootstrap(s, "general", (1, "alice"), (2, "bob"), (3, "charlie"))
+    _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice", "bob"], "private": False,
+        "prompt": "",
+    })
+    _send(s, 3, "join_thread", {"thread_id": "general-t001"})
+    assert s.threads["general-t001"].members == ["alice", "bob", "charlie"]
+
+
+def test_join_thread_private_is_rejected():
+    s = LobbyState()
+    _bootstrap(s, "general", (1, "alice"), (2, "bob"), (3, "charlie"))
+    _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice", "bob"], "private": True,
+        "prompt": "",
+    })
+    out = _send(s, 3, "join_thread", {"thread_id": "general-t001"})
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"] == "private_thread"
+
+
+def test_close_thread_requires_initiator():
+    s = LobbyState()
+    tid = _open_thread_abc(s)
+    out = _send(s, 2, "close_thread", {"thread_id": tid})
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"] == "not_initiator"
+
+
+def test_close_thread_by_initiator_succeeds():
+    s = LobbyState()
+    tid = _open_thread_abc(s)
+    out = _send(s, 1, "close_thread", {"thread_id": tid})
+    assert out == []
+    assert s.threads[tid].state == "closed"
+
+
+def test_leave_thread_transfers_initiator_ownership():
+    s = LobbyState()
+    tid = _open_thread_abc(s, prompt="")
+    _send(s, 1, "leave_thread", {"thread_id": tid})
+    assert s.threads[tid].initiator == "bob"
+    assert s.threads[tid].members == ["bob", "charlie"]
+
+
+def test_leave_thread_adjusts_cursor():
+    """If the member leaving is before the cursor, cursor shifts left."""
+    s = LobbyState()
+    tid = _open_thread_abc(s)  # cursor at bob (idx 1) after alice's prompt
+    # alice (idx 0) leaves — cursor 1 → 0 (now points to bob, who is now at 0)
+    _send(s, 1, "leave_thread", {"thread_id": tid})
+    assert s.threads[tid].current_speaker == "bob"
+
+
+# ─── Humans ──────────────────────────────────────────────────────────────────
+
+def test_human_say_bypasses_turn_and_resets_cursor():
+    s = LobbyState()
+    # Three clives + one human in the same room.
+    _bootstrap(s, "general", (1, "alice"), (2, "bob"), (3, "charlie"))
+    _hello(s, 10, "helen", client_kind="human")
+    _send(s, 10, "join_room", {"room": "general"})
+    # Alice opens a thread with alice+bob+charlie (helen not in members).
+    _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice", "bob", "charlie"],
+        "private": False, "prompt": "start",
+    })
+    # Cursor now at bob (idx 1). Helen injects.
+    out = _send(s, 10, "say", {"thread_id": "general-t001", "body": "redirect!"})
+    says = _outbound_by_kind(out, "say")
+    turns = _outbound_by_kind(out, "your_turn")
+    # Fanout reaches alice, bob, charlie (all thread members).
+    assert {s.session_id for s in says} == {1, 2, 3}
+    assert all(s.payload["from"] == "helen" for s in says)
+    # Cursor reset to 0 → alice receives your_turn.
+    assert len(turns) == 1 and turns[0].session_id == 1
+
+
+def test_human_pass_is_rejected():
+    s = LobbyState()
+    _hello(s, 10, "helen", client_kind="human")
+    _bootstrap(s, "general", (1, "alice"))
+    _send(s, 10, "join_room", {"room": "general"})
+    _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice"], "private": False, "prompt": "",
+    })
+    out = _send(s, 10, "pass", {"thread_id": "general-t001"})
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"] == "humans_do_not_pass"
+
+
+# ─── recent window ───────────────────────────────────────────────────────────
+
+def test_recent_window_caps_at_K():
+    """your_turn.recent must be capped at recent_window (default 50)."""
+    s = LobbyState()
+    s.recent_window = 3  # shrink for test clarity
+    tid = _open_thread_abc(s, prompt="m0")
+    # Drive several rotations of say. Each say's your_turn carries the
+    # last N=3 messages only.
+    for i in range(5):
+        speaker_session = ((i + 1) % 3) + 1  # bob=2, charlie=3, alice=1, ...
+        _send(s, speaker_session, "say",
+              {"thread_id": tid, "body": f"m{i+1}"})
+    # Next your_turn (emitted last) should have only the 3 most recent.
+    t = s.threads[tid]
+    assert len(t.messages) == 6
+    # Simulate another say to check the outbound your_turn payload.
+    speaker_session = (6 % 3) + 1
+    out = _send(s, speaker_session, "say", {"thread_id": tid, "body": "m6"})
+    turn = _outbound_by_kind(out, "your_turn")[0]
+    assert len(turn.payload["recent"]) == 3
+    # And it's the TAIL — last three messages.
+    recent_bodies = [e["body"] for e in turn.payload["recent"]]
+    assert recent_bodies == ["m4", "m5", "m6"]

--- a/tests/test_lobby_state.py
+++ b/tests/test_lobby_state.py
@@ -427,6 +427,153 @@ def test_human_pass_is_rejected():
 
 # ─── recent window ───────────────────────────────────────────────────────────
 
+# ─── Review regressions: critical bugs found in fresh review ─────────────────
+
+def test_quiescence_with_prompt_takes_exactly_one_rotation():
+    """C1 regression: dormancy must kick in after len(members)
+    consecutive passes regardless of cursor starting position. The
+    prior `cursor == 0` gate produced ~1.67 rotations before dormancy
+    when a prompt was present."""
+    s = LobbyState()
+    tid = _open_thread_abc(s, prompt="go")  # cursor starts at bob (1)
+    _send(s, 2, "pass", {"thread_id": tid})
+    _send(s, 3, "pass", {"thread_id": tid})
+    out = _send(s, 1, "pass", {"thread_id": tid})
+    # After exactly 3 consecutive passes the thread is dormant.
+    assert s.threads[tid].state == "dormant"
+    assert _outbound_by_kind(out, "your_turn") == []
+
+
+def test_human_cannot_say_in_thread_without_joining_room():
+    """C2 regression: humans injecting say must be room members. The
+    prior _resolve_thread exemption for humans bypassed all locality
+    checks."""
+    s = LobbyState()
+    _bootstrap(s, "general", (1, "alice"), (2, "bob"))
+    _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice", "bob"],
+        "private": False, "prompt": "",
+    })
+    # helen is a human that has NOT joined 'general'.
+    _hello(s, 10, "helen", client_kind="human")
+    out = _send(s, 10, "say", {"thread_id": "general-t001", "body": "hi"})
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"] == "not_in_room"
+
+
+def test_human_cannot_inject_into_private_thread_they_are_not_member_of():
+    """C2 regression: private-thread isolation extends to inbound say.
+    Before the fix a human in the room could post into any private
+    thread whose id they knew."""
+    s = LobbyState()
+    _bootstrap(s, "general", (1, "alice"), (2, "bob"))
+    _hello(s, 10, "helen", client_kind="human")
+    _send(s, 10, "join_room", {"room": "general"})
+    _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice", "bob"],
+        "private": True, "prompt": "",
+    })
+    out = _send(s, 10, "say", {"thread_id": "general-t001", "body": "leak"})
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"] == "private_thread"
+
+
+def test_public_thread_fanout_reaches_room_observers():
+    """C3 regression: design §4.3 — public threads fan out to all room
+    members, not just thread members."""
+    s = LobbyState()
+    _bootstrap(s, "general", (1, "alice"), (2, "bob"), (3, "observer"))
+    # Thread: alice + bob only; observer is in the room but NOT the thread.
+    _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice", "bob"],
+        "private": False, "prompt": "",
+    })
+    # No prompt -> cursor at alice. Alice says.
+    out = _send(s, 1, "say", {"thread_id": "general-t001", "body": "hey"})
+    says = _outbound_by_kind(out, "say")
+    session_ids = {s.session_id for s in says}
+    assert 2 in session_ids  # bob (thread member)
+    assert 3 in session_ids  # observer (room member, not in thread)
+
+
+def test_private_thread_fanout_excludes_room_observers():
+    """C3: private threads must NOT leak to non-member observers even
+    though they are in the same room."""
+    s = LobbyState()
+    _bootstrap(s, "general", (1, "alice"), (2, "bob"), (3, "observer"))
+    _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice", "bob"],
+        "private": True, "prompt": "",
+    })
+    out = _send(s, 1, "say", {"thread_id": "general-t001", "body": "secret"})
+    says = _outbound_by_kind(out, "say")
+    session_ids = {s.session_id for s in says}
+    assert 3 not in session_ids  # observer must not see private content
+    assert 2 in session_ids      # bob (member) does
+
+
+def test_current_speaker_leaving_emits_your_turn_to_next():
+    """H1 regression: when the current speaker leaves, the new cursor
+    holder must be notified via your_turn."""
+    s = LobbyState()
+    tid = _open_thread_abc(s)  # cursor at bob (1) after alice's prompt
+    out = _send(s, 2, "leave_thread", {"thread_id": tid})
+    turns = _outbound_by_kind(out, "your_turn")
+    # bob leaves; members becomes [alice, charlie]; cursor adjusts to
+    # charlie (was at bob's slot). Charlie gets the turn.
+    assert len(turns) == 1
+    assert turns[0].payload["name"] == "charlie"
+
+
+def test_non_current_speaker_leaving_does_not_emit_your_turn():
+    """H1: the converse — if a non-speaker leaves, no redundant
+    your_turn is fired."""
+    s = LobbyState()
+    tid = _open_thread_abc(s)  # cursor at bob
+    out = _send(s, 3, "leave_thread", {"thread_id": tid})  # charlie, not speaker
+    assert _outbound_by_kind(out, "your_turn") == []
+
+
+def test_open_thread_rejects_humans_in_members():
+    """H2 regression: humans are never in rotation, so they cannot
+    appear in the members list. (This implicitly forbids human-
+    initiated threads in v1; noted in design open items.)"""
+    s = LobbyState()
+    _bootstrap(s, "general", (1, "alice"), (2, "bob"))
+    _hello(s, 10, "helen", client_kind="human")
+    _send(s, 10, "join_room", {"room": "general"})
+    out = _send(s, 1, "open_thread", {
+        "room": "general", "members": ["alice", "helen"],
+        "private": False, "prompt": "",
+    })
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"].startswith("human_in_members")
+
+
+def test_clive_say_requires_room_membership_after_reconnect():
+    """A reconnecting clive who is still in thread.members but whose
+    old session's room membership was dropped must rejoin the room
+    before they can say."""
+    s = LobbyState()
+    tid = _open_thread_abc(s)  # cursor at bob after alice's prompt
+    # bob drops and reconnects without rejoining the room.
+    s.drop_session(2)
+    _hello(s, 22, "bob")
+    assert "bob" in s.threads[tid].members  # thread membership survives
+    out = _send(s, 22, "say", {"thread_id": tid, "body": "back"})
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"] == "not_in_room"
+
+
+def test_whitespace_only_say_body_is_nacked():
+    """M2: an entirely-whitespace body is not a valid message."""
+    s = LobbyState()
+    tid = _open_thread_abc(s)
+    out = _send(s, 2, "say", {"thread_id": tid, "body": "   \t\n"})
+    assert out[0].kind == "nack"
+    assert out[0].payload["reason"] == "invalid_body"
+
+
 def test_recent_window_caps_at_K():
     """your_turn.recent must be capped at recent_window (default 50)."""
     s = LobbyState()

--- a/tests/test_room_participant.py
+++ b/tests/test_room_participant.py
@@ -1,0 +1,320 @@
+"""Tests for ``execution/room_participant.py`` — the client-side glue
+that turns the stateful room_runner into a transport-agnostic line
+processor usable by ConvLoop (or any other selectors wrapper).
+
+Design goal: the participant is IO-free. ``bootstrap()`` and
+``on_line()`` return lists of encoded frame strings; the caller owns
+the socket/pipe and the writing. This separation mirrors the split
+between ``lobby_state`` (pure) and ``lobby_server`` (IO) on the lobby
+side.
+
+See docs/plans/2026-04-14-clive-rooms-design.md §6.2 and §6.3.
+"""
+from __future__ import annotations
+
+import socket
+import threading
+import time
+
+import pytest
+
+from protocol import decode_all, encode
+from room_participant import RoomParticipant
+
+
+# ─── Fake LLM client (duck-types llm.chat()'s openai-else branch) ────────────
+
+
+class _FakeClient:
+    def __init__(self, content: str):
+        self._content = content
+        self.chat = self
+        self.completions = self
+
+    def create(self, **_):
+        class _U: prompt_tokens = 1; completion_tokens = 1
+        class _M: pass
+        m = _M(); m.content = self._content
+        class _C: pass
+        c = _C(); c.message = m
+        class _R: pass
+        r = _R(); r.choices = [c]; r.usage = _U()
+        return r
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _frames(lines: list[str], nonce: str):
+    """Flatten a list of framed lines to a list of Frame objects."""
+    return [f for line in lines for f in decode_all(line, nonce=nonce)]
+
+
+# ─── Bootstrap ──────────────────────────────────────────────────────────────
+
+
+def test_bootstrap_emits_hello_then_joins():
+    """Bootstrap must produce exactly one session_hello followed by
+    one join_room per requested room, in the order given. The lobby
+    dispatches them sequentially on the same connection so hello
+    lands before the joins and the joins succeed."""
+    p = RoomParticipant(name="alice", nonce="n", llm_client=None)
+    out = p.bootstrap(rooms=["general", "council"])
+    frames = _frames(out, "n")
+    assert [f.kind for f in frames] == [
+        "session_hello", "join_room", "join_room",
+    ]
+    assert frames[0].payload == {"client_kind": "clive", "name": "alice"}
+    assert frames[1].payload == {"room": "general"}
+    assert frames[2].payload == {"room": "council"}
+
+
+def test_bootstrap_with_no_rooms_still_sends_hello():
+    p = RoomParticipant(name="alice", nonce="n", llm_client=None)
+    out = p.bootstrap(rooms=[])
+    frames = _frames(out, "n")
+    assert [f.kind for f in frames] == ["session_hello"]
+
+
+def test_bootstrap_stamps_the_participant_nonce():
+    """Frames must carry the participant's own nonce so the lobby
+    accepts them — and so a peer's scrollback (decoded with a
+    different nonce) cannot mistake them for its own traffic."""
+    p = RoomParticipant(name="alice", nonce="nA", llm_client=None)
+    out = p.bootstrap(rooms=["general"])
+    # Decoded with the wrong nonce → nothing.
+    assert _frames(out, "wrong") == []
+    # Decoded with the right one → both frames present.
+    assert len(_frames(out, "nA")) == 2
+
+
+# ─── on_line dispatch ───────────────────────────────────────────────────────
+
+
+def _your_turn_line(nonce: str, **overrides) -> str:
+    payload = {
+        "thread_id": "T1", "room": "general", "name": "alice",
+        "members": ["alice", "bob"], "message_index": 0,
+        "recent": [{"from": "bob", "kind": "say", "body": "what's 2+2?"}],
+    }
+    payload.update(overrides)
+    return encode("your_turn", payload, nonce=nonce) + "\n"
+
+
+def test_your_turn_produces_say_frame():
+    p = RoomParticipant(name="alice", nonce="n",
+                        llm_client=_FakeClient("say: 4\nDONE:"),
+                        driver_text="D")
+    out = p.on_line(_your_turn_line("n"))
+    frames = _frames(out, "n")
+    assert [f.kind for f in frames] == ["say"]
+    assert frames[0].payload == {"thread_id": "T1", "body": "4"}
+
+
+def test_your_turn_pass_decision_produces_pass_frame():
+    p = RoomParticipant(name="alice", nonce="n",
+                        llm_client=_FakeClient("pass:\nDONE:"),
+                        driver_text="D")
+    out = p.on_line(_your_turn_line("n"))
+    frames = _frames(out, "n")
+    assert [f.kind for f in frames] == ["pass"]
+    assert frames[0].payload == {"thread_id": "T1"}
+
+
+def test_wrong_nonce_your_turn_is_silently_dropped():
+    """§7.2 nonce model: a `your_turn` with a nonce that is not this
+    participant's own must be silently dropped without triggering an
+    LLM call or a reply. This is the primary defence against a
+    compromised lobby (or prompt injection) forging turn grants."""
+    p = RoomParticipant(name="alice", nonce="real",
+                        llm_client=_FakeClient("say: forged\nDONE:"),
+                        driver_text="D")
+    out = p.on_line(_your_turn_line("attacker"))
+    assert out == []
+
+
+def test_informational_frames_produce_no_outbound():
+    """say/pass fanout, thread_opened, session_ack are informational
+    to the member — they must not trigger outbound frames. This is
+    what keeps alice from accidentally amplifying the conversation."""
+    p = RoomParticipant(name="alice", nonce="n",
+                        llm_client=_FakeClient("say: never\nDONE:"),
+                        driver_text="D")
+    for kind, payload in [
+        ("session_ack", {"name": "alice", "accepted": True}),
+        ("thread_opened", {"thread_id": "T1"}),
+        ("say", {"thread_id": "T1", "body": "hi", "from": "bob"}),
+        ("pass", {"thread_id": "T1", "from": "bob"}),
+        ("nack", {"reason": "invalid_body", "ref_kind": "say"}),
+        ("threads", {"room": "general", "threads": []}),
+    ]:
+        line = encode(kind, payload, nonce="n") + "\n"
+        assert p.on_line(line) == [], f"{kind} triggered outbound"
+
+
+def test_multiple_frames_on_one_line_each_dispatched():
+    """Lobby sometimes batches frames into a single socket write
+    (say fanout + your_turn during the same dispatch). The line
+    decoder returns both frames; the participant must handle each
+    and accumulate the outbound responses."""
+    p = RoomParticipant(name="alice", nonce="n",
+                        llm_client=_FakeClient("say: 4\nDONE:"),
+                        driver_text="D")
+    say = encode("say", {"thread_id": "T1", "body": "setup",
+                         "from": "bob"}, nonce="n")
+    yt = encode("your_turn", {
+        "thread_id": "T1", "room": "general", "name": "alice",
+        "members": ["alice", "bob"], "message_index": 1,
+        "recent": [{"from": "bob", "kind": "say", "body": "setup"}],
+    }, nonce="n")
+    # Both on one line; decode_all finds both.
+    out = p.on_line(say + yt + "\n")
+    frames = _frames(out, "n")
+    assert [f.kind for f in frames] == ["say"]
+    assert frames[0].payload == {"thread_id": "T1", "body": "4"}
+
+
+def test_your_turn_with_llm_exception_degrades_to_pass(monkeypatch):
+    """If the LLM call explodes mid-turn, the participant must still
+    produce a pass frame so the lobby's rotation advances. Otherwise
+    one flaky model wedges the whole thread at that member."""
+    import llm as _llm
+
+    def _boom(*a, **kw):
+        raise RuntimeError("synthetic")
+    monkeypatch.setattr(_llm, "chat", _boom)
+
+    p = RoomParticipant(name="alice", nonce="n",
+                        llm_client=object(),   # llm.chat patched out
+                        driver_text="D")
+    out = p.on_line(_your_turn_line("n"))
+    frames = _frames(out, "n")
+    assert [f.kind for f in frames] == ["pass"]
+    assert frames[0].payload == {"thread_id": "T1"}
+
+
+# ─── Integration with a real lobby_server ────────────────────────────────────
+
+
+def test_participant_completes_turn_against_real_lobby(tmp_path):
+    """End-to-end: the participant boots against a live lobby socket,
+    receives your_turn after a peer opens a thread, and its reply is
+    fanned out to the peer under the peer's nonce. This is the first
+    test where ALL four layers (lobby_state, lobby_server, protocol,
+    room_participant + room_runner) are live at once — if any glue
+    between them is wrong, it shows up here."""
+    import tempfile, os
+    from lobby_server import LobbyServer
+
+    # Short socket path for macOS AF_UNIX length limit.
+    fd, sock_path = tempfile.mkstemp(prefix="clv-", suffix=".sock")
+    os.close(fd); os.unlink(sock_path)
+
+    srv = LobbyServer(socket_path=sock_path, registry_dir=tmp_path,
+                      instance_name="p4-lobby")
+    srv.start()
+    srv_t = threading.Thread(target=srv.run_forever, daemon=True)
+    srv_t.start()
+    try:
+        # Alice: participant driven over a blocking socket.
+        alice = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        for _ in range(50):
+            try:
+                alice.connect(sock_path); break
+            except (FileNotFoundError, ConnectionRefusedError):
+                time.sleep(0.02)
+        alice.sendall(b"NONCE nA\n")
+        participant = RoomParticipant(
+            name="alice", nonce="nA",
+            llm_client=_FakeClient("say: 4\nDONE:"),
+            driver_text="D",
+        )
+        for frame in participant.bootstrap(rooms=["general"]):
+            alice.sendall((frame + "\n").encode())
+
+        # Bob: raw driver that opens a thread with alice.
+        bob = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        bob.connect(sock_path)
+        bob.sendall(b"NONCE nB\n")
+        bob.sendall((encode("session_hello",
+                            {"client_kind": "clive", "name": "bob"},
+                            nonce="nB") + "\n").encode())
+        # Drain bob's session_ack.
+        bob.settimeout(1.0); bob.recv(4096)
+        bob.sendall((encode("join_room", {"room": "general"},
+                            nonce="nB") + "\n").encode())
+        time.sleep(0.1)
+        bob.sendall((encode("open_thread", {
+            "room": "general", "members": ["bob", "alice"],
+            "private": False, "prompt": "what's 2+2?",
+        }, nonce="nB") + "\n").encode())
+
+        # Alice-side reader: pull lines from alice socket, feed to
+        # participant, send outbound frames back. Runs in a thread so
+        # we can drive bob from the main test.
+        alice.settimeout(0.2)
+        alice_stop = threading.Event()
+
+        def _drive():
+            buf = b""
+            while not alice_stop.is_set():
+                try:
+                    chunk = alice.recv(4096)
+                except socket.timeout:
+                    continue
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                buf += chunk
+                while b"\n" in buf:
+                    nl = buf.index(b"\n")
+                    line = buf[:nl + 1].decode("utf-8", errors="replace")
+                    buf = buf[nl + 1:]
+                    for out in participant.on_line(line):
+                        try:
+                            alice.sendall((out + "\n").encode())
+                        except OSError:
+                            return
+
+        drv = threading.Thread(target=_drive, daemon=True)
+        drv.start()
+        try:
+            # Bob should now receive: thread_opened, then alice's `say`
+            # fanout (body "4") after alice's participant runs the LLM
+            # and emits the reply.
+            bob.settimeout(2.0)
+            data = b""
+            deadline = time.time() + 3.0
+            got_alice_say = False
+            while time.time() < deadline and not got_alice_say:
+                try:
+                    chunk = bob.recv(4096)
+                except socket.timeout:
+                    break
+                if not chunk:
+                    break
+                data += chunk
+                for f in decode_all(data.decode("utf-8", errors="replace"),
+                                    nonce="nB"):
+                    if (f.kind == "say"
+                            and f.payload.get("from") == "alice"
+                            and f.payload.get("body") == "4"):
+                        got_alice_say = True
+                        break
+            assert got_alice_say, (
+                "alice's say was never fanned out to bob; "
+                f"bob saw: {data!r}"
+            )
+        finally:
+            alice_stop.set()
+            drv.join(timeout=1.0)
+            alice.close()
+            bob.close()
+    finally:
+        srv.shutdown()
+        srv_t.join(timeout=2.0)
+        try:
+            os.unlink(sock_path)
+        except FileNotFoundError:
+            pass

--- a/tests/test_room_participant.py
+++ b/tests/test_room_participant.py
@@ -152,6 +152,57 @@ def test_informational_frames_produce_no_outbound():
         assert p.on_line(line) == [], f"{kind} triggered outbound"
 
 
+def test_successive_lines_each_dispatched_independently():
+    """Matches the actual production wire format: the lobby writes
+    each frame with a trailing '\\n', so the line parser delivers
+    exactly one frame per ``on_line`` call. `test_multiple_frames...`
+    (below) covers the defensive multi-frame case; this one covers
+    what actually runs."""
+    p = RoomParticipant(name="alice", nonce="n",
+                        llm_client=_FakeClient("say: 4\nDONE:"),
+                        driver_text="D")
+    say_line = encode("say", {"thread_id": "T1", "body": "setup",
+                              "from": "bob"}, nonce="n") + "\n"
+    yt_line = _your_turn_line("n")
+
+    assert p.on_line(say_line) == []          # informational, no outbound
+    out = p.on_line(yt_line)                  # your_turn → reply
+    frames = _frames(out, "n")
+    assert [f.kind for f in frames] == ["say"]
+    assert frames[0].payload == {"thread_id": "T1", "body": "4"}
+
+
+def test_driver_text_is_cached_after_first_your_turn(monkeypatch):
+    """The driver file is re-used across turns, not re-read each
+    time. Many rooms messages on the same thread would otherwise
+    pay a per-turn file IO tax for no reason. We pin this by
+    counting load_driver calls through the participant."""
+    import room_runner as _rr
+    calls = {"n": 0}
+    real = _rr.load_driver
+
+    def _counting_load():
+        calls["n"] += 1
+        return real()
+
+    monkeypatch.setattr(_rr, "load_driver", _counting_load)
+    # RoomParticipant imports load_driver at module import time, so
+    # we need to patch on the participant module too.
+    import room_participant as _rp
+    monkeypatch.setattr(_rp, "load_driver", _counting_load)
+
+    p = RoomParticipant(name="alice", nonce="n",
+                        llm_client=_FakeClient("pass:\nDONE:"))
+    # No driver_text passed — expect lazy load on first your_turn.
+    assert calls["n"] == 0
+    p.on_line(_your_turn_line("n"))
+    assert calls["n"] == 1, "driver was not loaded on first turn"
+    p.on_line(_your_turn_line("n"))
+    p.on_line(_your_turn_line("n"))
+    assert calls["n"] == 1, \
+        f"driver was re-loaded ({calls['n']} times) — should cache"
+
+
 def test_multiple_frames_on_one_line_each_dispatched():
     """Lobby sometimes batches frames into a single socket write
     (say fanout + your_turn during the same dispatch). The line

--- a/tests/test_room_runner.py
+++ b/tests/test_room_runner.py
@@ -1,0 +1,240 @@
+"""Tests for ``execution/room_runner.py``.
+
+The room runner is the client-side LLM loop a member clive runs when
+it receives a ``your_turn`` frame from the lobby. It is *pure w.r.t.
+IO*: given a parsed your_turn payload and a chat function, it returns
+the single frame to emit (``say`` or ``pass``). Integration with the
+selectors loop + socket lives in later phases.
+
+See docs/plans/2026-04-14-clive-rooms-design.md §6.2 (room runner) and
+§6.4 (room driver).
+"""
+from __future__ import annotations
+
+import pytest
+
+from room_runner import decide_turn, build_messages, parse_response, load_driver
+
+
+# ─── load_driver ─────────────────────────────────────────────────────────────
+
+
+def test_load_driver_returns_non_empty_text():
+    text = load_driver()
+    # Load the packaged drivers/room.md. Assert the high-leverage
+    # fragments are present so a future accidental overwrite that
+    # strips the response format (the "highest-leverage driver
+    # change" per memory/project_autoresearch_driver_findings.md) is
+    # caught here.
+    assert "say:" in text
+    assert "pass:" in text
+    assert "DONE:" in text
+    assert "PASS IS THE NORM" in text
+
+
+# ─── build_messages ──────────────────────────────────────────────────────────
+
+
+def test_build_messages_includes_driver_as_system():
+    payload = {
+        "thread_id": "general-t001",
+        "room": "general",
+        "name": "alice",
+        "members": ["alice", "bob"],
+        "message_index": 0,
+        "recent": [],
+    }
+    msgs = build_messages(payload, driver_text="DRIVER_PROSE")
+    assert msgs[0]["role"] == "system"
+    assert msgs[0]["content"] == "DRIVER_PROSE"
+
+
+def test_build_messages_user_block_has_identity_header():
+    """Per §6.2 the user block must carry a structured header with
+    name / thread_id / room / members so the LLM never has to infer
+    identity from scrollback."""
+    payload = {
+        "thread_id": "general-t007",
+        "room": "general",
+        "name": "alice",
+        "members": ["alice", "bob", "charlie"],
+        "message_index": 3,
+        "recent": [],
+    }
+    msgs = build_messages(payload, driver_text="D")
+    user = next(m for m in msgs if m["role"] == "user")["content"]
+    assert "alice" in user
+    assert "general-t007" in user
+    assert "general" in user
+    # member list preserved in order
+    assert user.index("alice") < user.index("bob") < user.index("charlie")
+
+
+def test_build_messages_formats_recent_as_lines():
+    payload = {
+        "thread_id": "t", "room": "r", "name": "alice",
+        "members": ["alice", "bob"], "message_index": 2,
+        "recent": [
+            {"from": "bob", "kind": "say", "body": "let's decide"},
+            {"from": "alice", "kind": "pass"},
+        ],
+    }
+    user = next(m for m in build_messages(payload, driver_text="D")
+                if m["role"] == "user")["content"]
+    assert "bob: let's decide" in user
+    assert "alice: (pass)" in user
+
+
+def test_build_messages_includes_summary_when_present():
+    payload = {
+        "thread_id": "t", "room": "r", "name": "alice",
+        "members": ["alice", "bob"], "message_index": 72,
+        "recent": [],
+        "summary": "Earlier: the team agreed on option B.",
+    }
+    user = next(m for m in build_messages(payload, driver_text="D")
+                if m["role"] == "user")["content"]
+    assert "Earlier: the team agreed on option B." in user
+
+
+def test_build_messages_omits_summary_section_when_absent():
+    payload = {
+        "thread_id": "t", "room": "r", "name": "alice",
+        "members": ["alice", "bob"], "message_index": 2,
+        "recent": [],
+    }
+    user = next(m for m in build_messages(payload, driver_text="D")
+                if m["role"] == "user")["content"]
+    # Shouldn't leak a blank "Earlier:" header when no summary exists.
+    assert "Earlier:" not in user
+    assert "summary" not in user.lower()
+
+
+# ─── parse_response ──────────────────────────────────────────────────────────
+
+
+def test_parse_say_extracts_body():
+    kind, payload = parse_response(
+        "say: I propose option B.\nDONE:",
+        thread_id="t1",
+    )
+    assert kind == "say"
+    assert payload == {"thread_id": "t1", "body": "I propose option B."}
+
+
+def test_parse_pass_returns_pass_frame():
+    kind, payload = parse_response("pass:\nDONE:", thread_id="t1")
+    assert kind == "pass"
+    assert payload == {"thread_id": "t1"}
+
+
+def test_parse_tolerates_leading_whitespace_and_case():
+    kind, payload = parse_response("  Say: hello there\nDONE:", thread_id="t1")
+    assert kind == "say"
+    assert payload["body"] == "hello there"
+
+    kind, _ = parse_response("   PASS:\nDONE:", thread_id="t1")
+    assert kind == "pass"
+
+
+def test_parse_empty_body_degrades_to_pass():
+    """An LLM that emits `say:` with no body violates the driver; we
+    degrade to `pass` rather than emit an invalid-body frame that the
+    lobby would nack. Emitting a nacked frame would waste the turn and
+    the lobby would auto-pass on timeout anyway — passing here is the
+    same outcome with lower noise."""
+    kind, payload = parse_response("say:\nDONE:", thread_id="t1")
+    assert kind == "pass"
+    assert payload == {"thread_id": "t1"}
+
+
+def test_parse_no_say_or_pass_degrades_to_pass():
+    """Garbage LLM output → safe pass, never a malformed frame."""
+    kind, _ = parse_response("I think this is interesting.", thread_id="t1")
+    assert kind == "pass"
+
+
+def test_parse_multiline_say_body_preserved_up_to_done():
+    """Per §6.2 the driver expects single-line say, but a slightly
+    loose model may wrap. Accept multi-line body up to the DONE: line,
+    so we don't lose content a human would consider valid."""
+    content = "say: first line\nsecond line\nthird line\nDONE:"
+    kind, payload = parse_response(content, thread_id="t1")
+    assert kind == "say"
+    assert payload["body"] == "first line\nsecond line\nthird line"
+
+
+def test_parse_take_first_directive_only():
+    """Driver forbids multiple directives. If the model produces two,
+    the first wins — we must NOT emit multiple frames (would break
+    turn discipline)."""
+    content = "say: first answer\nDONE:\npass:\nDONE:"
+    kind, payload = parse_response(content, thread_id="t1")
+    assert kind == "say"
+    assert payload["body"] == "first answer"
+
+
+# ─── decide_turn (integration with a mock LLM) ───────────────────────────────
+
+
+class _FakeClient:
+    """Minimal duck-type for llm.chat()'s openai-else branch. Returns
+    a canned content string."""
+    def __init__(self, content: str):
+        self._content = content
+        self.chat = self
+        self.completions = self
+
+    def create(self, **kwargs):
+        class _Usage:
+            prompt_tokens = 42
+            completion_tokens = 7
+        class _Msg:
+            pass
+        msg = _Msg()
+        msg.content = self._content
+        class _Choice:
+            pass
+        choice = _Choice()
+        choice.message = msg
+
+        class _Resp:
+            pass
+        resp = _Resp()
+        resp.choices = [choice]
+        resp.usage = _Usage()
+        return resp
+
+
+def test_decide_turn_produces_say_frame(monkeypatch):
+    payload = {
+        "thread_id": "general-t007", "room": "general", "name": "alice",
+        "members": ["alice", "bob"], "message_index": 2,
+        "recent": [{"from": "bob", "kind": "say", "body": "what's 2+2?"}],
+    }
+    client = _FakeClient("say: 4\nDONE:")
+    kind, out = decide_turn(payload, llm_client=client, driver_text="D")
+    assert kind == "say"
+    assert out == {"thread_id": "general-t007", "body": "4"}
+
+
+def test_decide_turn_produces_pass_frame():
+    payload = {
+        "thread_id": "T", "room": "r", "name": "alice",
+        "members": ["alice", "bob"], "message_index": 2, "recent": [],
+    }
+    client = _FakeClient("pass:\nDONE:")
+    kind, out = decide_turn(payload, llm_client=client, driver_text="D")
+    assert kind == "pass"
+    assert out == {"thread_id": "T"}
+
+
+def test_decide_turn_degrades_to_pass_on_garbage():
+    payload = {
+        "thread_id": "T", "room": "r", "name": "alice",
+        "members": ["alice", "bob"], "message_index": 2, "recent": [],
+    }
+    client = _FakeClient("I'm sorry, I don't understand.")
+    kind, out = decide_turn(payload, llm_client=client, driver_text="D")
+    assert kind == "pass"
+    assert out == {"thread_id": "T"}

--- a/tests/test_room_runner.py
+++ b/tests/test_room_runner.py
@@ -57,7 +57,10 @@ def test_build_messages_user_block_has_identity_header():
         "thread_id": "general-t007",
         "room": "general",
         "name": "alice",
-        "members": ["alice", "bob", "charlie"],
+        # Deliberately use names that do NOT overlap with `name: alice`
+        # so a substring-order assertion actually probes members-list
+        # ordering rather than being satisfied by the `name:` line.
+        "members": ["alice", "xavier", "yvonne"],
         "message_index": 3,
         "recent": [],
     }
@@ -66,8 +69,10 @@ def test_build_messages_user_block_has_identity_header():
     assert "alice" in user
     assert "general-t007" in user
     assert "general" in user
-    # member list preserved in order
-    assert user.index("alice") < user.index("bob") < user.index("charlie")
+    # Members line must preserve the ordered list verbatim. Testing
+    # the exact rendered substring catches both reordering bugs and
+    # separator-format drift.
+    assert "members: alice, xavier, yvonne" in user
 
 
 def test_build_messages_formats_recent_as_lines():
@@ -225,6 +230,33 @@ def test_decide_turn_produces_pass_frame():
     }
     client = _FakeClient("pass:\nDONE:")
     kind, out = decide_turn(payload, llm_client=client, driver_text="D")
+    assert kind == "pass"
+    assert out == {"thread_id": "T"}
+
+
+def test_decide_turn_degrades_to_pass_on_llm_exception(monkeypatch):
+    """Any runtime failure from llm.chat — network hiccup, provider
+    auth error, rate limit — must not break the rotation. The runner
+    logs and emits a pass frame instead, so the lobby's turn cursor
+    advances and other members keep moving. Uncaught exceptions here
+    would wedge the member's own event loop for the whole thread."""
+    payload = {
+        "thread_id": "T", "room": "r", "name": "alice",
+        "members": ["alice", "bob"], "message_index": 2, "recent": [],
+    }
+
+    class _RaisingClient:
+        chat = None  # unused; we patch llm.chat itself below
+
+    import llm as _llm
+
+    def _boom(*args, **kwargs):
+        raise ConnectionError("synthetic network failure")
+
+    monkeypatch.setattr(_llm, "chat", _boom)
+
+    kind, out = decide_turn(payload, llm_client=_RaisingClient(),
+                            driver_text="D")
     assert kind == "pass"
     assert out == {"thread_id": "T"}
 

--- a/tests/test_rooms_cli.py
+++ b/tests/test_rooms_cli.py
@@ -1,0 +1,169 @@
+"""End-to-end CLI test for ``--join room@lobby``.
+
+Spawns a real ``clive --role broker`` subprocess as the lobby, then
+a second ``clive --name alice --conversational --join general@testlobby``
+subprocess that should connect, send bootstrap frames, and stay
+alive until we feed it ``exit`` on stdin.
+
+We verify the bootstrap traffic landed in the lobby by connecting a
+raw third socket and listing the room roster after alice joined.
+The LLM is not invoked in this test (no thread is opened), so we
+don't need to mock it — the test exercises the connector + bootstrap
+path, which is the part the library-level tests cannot touch.
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from protocol import decode_all, encode
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CLIVE_CMD = [sys.executable, str(REPO_ROOT / "clive.py")]
+
+
+@pytest.fixture
+def tmp_env(tmp_path, monkeypatch):
+    """Isolate ~/.clive so this test cannot see or clobber a user's
+    real registry. We point HOME at tmp_path so subprocesses inherit
+    the isolation via their own env."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    return {
+        "home": home,
+        "registry_dir": home / ".clive" / "instances",
+    }
+
+
+def _wait_for(predicate, *, timeout=3.0, interval=0.05):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def test_cli_join_flag_bootstraps_against_running_lobby(tmp_env):
+    """Full CLI path end-to-end. The lobby subprocess runs, registers,
+    and accepts. The member subprocess parses --join, resolves the
+    lobby name via the local registry, opens a Unix socket, completes
+    the NONCE handshake, and sends session_hello + join_room.
+
+    We verify the roster by opening a third socket as `observer`,
+    joining the same room, and opening a thread including alice — the
+    open_thread will be nacked with `members_not_in_room` if alice
+    did NOT actually join, so a green thread_opened proves the full
+    CLI path worked."""
+    sock_path = tempfile.mkdtemp(prefix="clv-cli-") + "/lobby.sock"
+
+    # Start the lobby.
+    broker = subprocess.Popen(
+        CLIVE_CMD + [
+            "--role", "broker",
+            "--name", "testlobby",
+            "--lobby-socket", sock_path,
+        ],
+        env={**os.environ, "HOME": str(tmp_env["home"])},
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+    )
+    try:
+        # Wait for the broker's socket to appear AND its registry
+        # entry to be written — both are set up in start() before
+        # run_forever() enters the event loop.
+        assert _wait_for(lambda: os.path.exists(sock_path)), \
+            f"lobby socket never appeared at {sock_path}"
+        assert _wait_for(
+            lambda: (tmp_env["registry_dir"] / "testlobby.json").exists()
+        ), "lobby registry entry never appeared"
+
+        # Start the member.
+        member = subprocess.Popen(
+            CLIVE_CMD + [
+                "--name", "alice",
+                "--conversational",
+                "--join", "general@testlobby",
+            ],
+            env={**os.environ, "HOME": str(tmp_env["home"])},
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        try:
+            # Give the member time to connect + bootstrap. We
+            # detect completion by polling the lobby as an observer
+            # and verifying alice is in-room.
+            time.sleep(0.5)   # cooperative: member connects, sends hello+join
+
+            # Observer: connect raw, send hello + join_room(general),
+            # then open_thread with alice — only succeeds if alice is
+            # a current room member.
+            obs = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            obs.connect(sock_path)
+            obs.sendall(b"NONCE nO\n")
+            obs.sendall((encode("session_hello",
+                                {"client_kind": "clive", "name": "observer"},
+                                nonce="nO") + "\n").encode())
+            obs.settimeout(1.0)
+            obs.recv(4096)   # session_ack
+            obs.sendall((encode("join_room", {"room": "general"},
+                                nonce="nO") + "\n").encode())
+            time.sleep(0.1)
+            obs.sendall((encode("open_thread", {
+                "room": "general",
+                "members": ["observer", "alice"],
+                "private": False,
+                "prompt": "ping",
+            }, nonce="nO") + "\n").encode())
+
+            # Read until we either see `thread_opened` (alice IS
+            # in-room) or `nack:members_not_in_room` (she isn't).
+            obs.settimeout(2.0)
+            data = b""
+            kinds = set()
+            deadline = time.time() + 3.0
+            while time.time() < deadline and "thread_opened" not in kinds \
+                    and "nack" not in kinds:
+                try:
+                    chunk = obs.recv(4096)
+                except socket.timeout:
+                    break
+                if not chunk:
+                    break
+                data += chunk
+                for f in decode_all(data.decode("utf-8", errors="replace"),
+                                    nonce="nO"):
+                    kinds.add(f.kind)
+
+            obs.close()
+            assert "thread_opened" in kinds, (
+                f"alice's --join did not place her in room `general`; "
+                f"observer's open_thread saw kinds: {sorted(kinds)}"
+            )
+        finally:
+            try:
+                member.stdin.write(b"exit\n")
+                member.stdin.flush()
+            except (BrokenPipeError, OSError):
+                pass
+            try:
+                member.wait(timeout=3.0)
+            except subprocess.TimeoutExpired:
+                member.kill()
+                member.wait(timeout=1.0)
+    finally:
+        broker.terminate()
+        try:
+            broker.wait(timeout=3.0)
+        except subprocess.TimeoutExpired:
+            broker.kill()
+            broker.wait(timeout=1.0)

--- a/tests/test_rooms_cli.py
+++ b/tests/test_rooms_cli.py
@@ -54,6 +54,120 @@ def _wait_for(predicate, *, timeout=3.0, interval=0.05):
     return False
 
 
+def test_join_without_name_is_rejected(tmp_env):
+    """`--join` silently no-oped without `--name` in earlier revisions
+    because the rooms wire-up lives inside the conversational
+    keep-alive branch, which is gated on `--name`. Now the argparse
+    layer surfaces the requirement with exit code 2 + a helpful
+    stderr message instead of letting the flag do nothing."""
+    proc = subprocess.run(
+        CLIVE_CMD + ["--conversational", "--join", "general@lobby"],
+        env={**os.environ, "HOME": str(tmp_env["home"])},
+        capture_output=True, timeout=10,
+    )
+    assert proc.returncode == 2, (
+        f"expected exit 2, got {proc.returncode}; "
+        f"stderr={proc.stderr.decode()[:400]}"
+    )
+    assert b"--join requires --name" in proc.stderr
+
+
+def test_join_auto_enables_conversational(tmp_env):
+    """`--join --name alice` must auto-enable conversational keep-alive
+    — otherwise the rooms wire-up is skipped and --join silently
+    does nothing. We prove this by launching alice without
+    `--conversational` and verifying she still bootstraps onto the
+    lobby (observer's open_thread listing alice succeeds iff alice
+    joined)."""
+    sock_path = tempfile.mkdtemp(prefix="clv-cli-") + "/lobby.sock"
+    broker = subprocess.Popen(
+        CLIVE_CMD + [
+            "--role", "broker",
+            "--name", "testlobby",
+            "--lobby-socket", sock_path,
+        ],
+        env={**os.environ, "HOME": str(tmp_env["home"])},
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+    )
+    try:
+        assert _wait_for(lambda: os.path.exists(sock_path)), \
+            "lobby socket never appeared"
+        assert _wait_for(
+            lambda: (tmp_env["registry_dir"] / "testlobby.json").exists()
+        ), "lobby registry entry never appeared"
+
+        # Deliberately omit `--conversational`. Previously this meant
+        # alice entered REPL mode instead of the keep-alive loop,
+        # and --join was ignored.
+        member = subprocess.Popen(
+            CLIVE_CMD + [
+                "--name", "alice",
+                "--join", "general@testlobby",
+            ],
+            env={**os.environ, "HOME": str(tmp_env["home"])},
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        try:
+            time.sleep(0.5)
+            obs = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            obs.connect(sock_path)
+            obs.sendall(b"NONCE nO\n")
+            obs.sendall((encode("session_hello",
+                                {"client_kind": "clive", "name": "observer"},
+                                nonce="nO") + "\n").encode())
+            obs.settimeout(1.0)
+            obs.recv(4096)
+            obs.sendall((encode("join_room", {"room": "general"},
+                                nonce="nO") + "\n").encode())
+            time.sleep(0.1)
+            obs.sendall((encode("open_thread", {
+                "room": "general",
+                "members": ["observer", "alice"],
+                "private": False,
+                "prompt": "ping",
+            }, nonce="nO") + "\n").encode())
+
+            obs.settimeout(2.0)
+            data = b""
+            kinds = set()
+            deadline = time.time() + 3.0
+            while time.time() < deadline and "thread_opened" not in kinds:
+                try:
+                    chunk = obs.recv(4096)
+                except socket.timeout:
+                    break
+                if not chunk:
+                    break
+                data += chunk
+                for f in decode_all(data.decode("utf-8", errors="replace"),
+                                    nonce="nO"):
+                    kinds.add(f.kind)
+            obs.close()
+            assert "thread_opened" in kinds, (
+                f"alice's --join did not take effect without explicit "
+                f"--conversational; observer saw: {sorted(kinds)}"
+            )
+        finally:
+            try:
+                member.stdin.write(b"exit\n")
+                member.stdin.flush()
+            except (BrokenPipeError, OSError):
+                pass
+            try:
+                member.wait(timeout=3.0)
+            except subprocess.TimeoutExpired:
+                member.kill()
+                member.wait(timeout=1.0)
+    finally:
+        broker.terminate()
+        try:
+            broker.wait(timeout=3.0)
+        except subprocess.TimeoutExpired:
+            broker.kill()
+            broker.wait(timeout=1.0)
+
+
 def test_cli_join_flag_bootstraps_against_running_lobby(tmp_env):
     """Full CLI path end-to-end. The lobby subprocess runs, registers,
     and accepts. The member subprocess parses --join, resolves the


### PR DESCRIPTION
## Summary

Ships phases 0–4 of the [13-section rooms design](docs/plans/2026-04-14-clive-rooms-design.md): always-on lobby brokers hosting persistent rooms that any number of clives can join; threads inside rooms enforce a uniform round-robin with first-class \`pass\`. Rooms is the first N-way clive-to-clive primitive — agent-to-agent (\`clive@host\`) is point-to-point only.

- **Protocol** (`networking/protocol.py`) — 14 new frame kinds; `your_turn` carries thread context structurally instead of relying on pane scrollback (§4.2).
- **Lobby state machine** (`networking/lobby_state.py`) — pure `handle(state, session_id, frame, now) -> list[Send]`; rooms, threads, rotation, fanout, initiator-only close. 43 tests.
- **Lobby IO server** (`networking/lobby_server.py`) — selectors + Unix socket + per-connection `NONCE` handshake; `--role broker`. Socket is 0o600 from the moment it exists (umask-wrapped bind).
- **SSH wrapper** (`networking/lobby_client.py`) — `--role lobby-client` bridges stdin/stdout ↔ lobby socket for a remote clive invoked over SSH.
- **Room driver + runner** (`drivers/room.md`, `execution/room_runner.py`) — pure turn decider; malformed LLM output degrades to `pass` rather than emitting a frame the lobby would nack.
- **Transport-agnostic glue** (`execution/room_participant.py`) — `bootstrap()` + `on_line()` turn lobby lines into outbound frames with no IO.
- **Selectors-based conv loop** (`session/conv_loop.py`) — replaces blocking `sys.stdin.readline()` so members can multiplex stdin + lobby socket; prereq for the wire-up.
- **`--join room@lobby` CLI flag** + localhost connector (`networking/lobby_connector.py`). `--join` auto-enables conversational and requires `--name` (both enforced at argparse time, not silently).
- **CHANGELOG / README** updated with a v0.6.0 entry and a §Rooms quickstart.

## Working quickstart

\`\`\`bash
# Terminal A
python clive.py --role broker --name lobby
# Terminal B
python clive.py --name alice --conversational --join general@lobby
# Terminal C
python clive.py --name bob --conversational --join general@lobby
\`\`\`

## Process

Every feature commit was followed by an explicit fresh-eyes review commit that caught real bugs before they got buried. Five such review/fix commits are on this branch, fixing: broker name collision silently clobbering, `sendall` on non-blocking socket exiting on transient back-pressure, `accept()` killing the event loop on `EMFILE`, socket permissions TOCTOU, self-pipe fd reuse at shutdown, partial-final-line EOF dropped (parity regression vs `readline()`), non-blocking flag leaking across tests, driver re-read per turn, `--join` silently no-oping without `--name`/`--conversational`, nonce alphabet not validated at the connector layer.

## Scope — not in this PR

- SSH transport (member → remote lobby over SSH subprocess). The `lobby-client` wrapper is ready; needs agents.yaml-based resolution to compose.
- Phase 5 JSONL persistence (thread history lost on broker restart).
- Phase 6 dropouts/timeouts (60s turn timeout, 30s alive-offline, initiator-drop ownership transfer).
- Phases 7–11 (rolling summarization, private threads, rate limits, human-member polish, integration evals).

## Test plan

- [x] \`pytest tests/\` — 894 tests, all green (was 821 on main; +73 net after accounting for scaffolding)
- [x] CLI subprocess end-to-end (\`tests/test_rooms_cli.py\`) — broker + member + observer over real Unix sockets in ~3s
- [x] Real-lobby integration (\`test_room_participant.py::test_participant_completes_turn_against_real_lobby\`) — all four layers (state machine + IO server + protocol + participant/runner) live at once
- [x] Subprocess-driven conversational parity (existing \`test_conversational_keepalive.py\` passes untouched after the ConvLoop refactor)
- [ ] Manual: three-terminal smoke test (not automated; documented in README §Rooms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)